### PR TITLE
fix: the action 'POP_TO_TOP' was not handled by any navigator

### DIFF
--- a/hooks/useRedirectWithoutHistory.ts
+++ b/hooks/useRedirectWithoutHistory.ts
@@ -7,8 +7,11 @@ export function useRedirectWithoutHistory() {
 
   const redirect = useCallback(
     (href: Href) => {
-      rootNavigation.dispatch(StackActions.popToTop());
-      router.replace(href);
+      // 检查是否可以返回到顶部
+      if (rootNavigation.canGoBack()) {
+        rootNavigation.dispatch(StackActions.popToTop());
+      }
+      router.replace(href); // 替换到目标路由
     },
     [rootNavigation],
   );


### PR DESCRIPTION
修正如下报错

```text
The action 'POP_TO_TOP' was not handled by any navigator.

Is there any screen to go back to?

This is a development-only warning and won't be shown in production.
anonymous @ console.js:614
reactConsoleErrorHandler @ ExceptionsManager.js:182
overrideMethod @ backend.js:17784
registerError @ LogBox.js:211
anonymous @ LogBox.js:79
onUnhandledAction @ ExpoRoot.js:167
dispatch @ useNavigationHelpers.js:35
anonymous @ BaseNavigationContainer.js:117
anonymous @ useFocusedListenersChildrenAdapter.js:37
anonymous @ BaseNavigationContainer.js:117
latestCallback @ index.js:15
anonymous @ createNavigationContainerRef.js:61
anonymous @ useRedirectWithoutHistory.ts:10
anonymous @ index.tsx:62
anonymous @ JSTimers.js:213
_callTimer @ JSTimers.js:111
callTimers @ JSTimers.js:359
__callFunction @ MessageQueue.js:434
anonymous @ MessageQueue.js:113
__guard @ MessageQueue.js:368
callFunctionReturnFlushedQueue @ MessageQueue.js:112
显示另外 19 个框架
收起
```