### PR TITLE
修复学期获取失败时没有进行空字符串检查的问题

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -30,7 +30,9 @@ export default function HomePage() {
     setLocateDateResult(res);
 
     const setting = await AsyncStorage.getItem(COURSE_SETTINGS_KEY);
-    const parsedSettings = normalizeCourseSetting(setting ? JSON.parse(setting) : { selectedSemester: res.semester });
+    const tryParsedSettings = setting ? JSON.parse(setting) : {};
+    const selectedSemester = tryParsedSettings.selectedSemester || res.semester;
+    const parsedSettings = normalizeCourseSetting({ selectedSemester });
 
     setConfig(parsedSettings);
     await AsyncStorage.setItem(COURSE_SETTINGS_KEY, JSON.stringify(parsedSettings));


### PR DESCRIPTION
点击切换学期时会尝试访问学期api，此时如果 cookie 过期则会触发重新登陆，如果此时访问教务处失败则会导致 semesters 为空，如果用户点击了确认，handleConfirmTermSelectPicker 中会将当前选择的学期设置为空字符串，但 app 启动时没有检查这种情况，就会导致 app 炸掉

添加 parse 后 selectedSemester 的空字符串检查