### PR TITLE
修正课表学期重叠的问题

### DIFF
--- a/components/course/calendar-col.tsx
+++ b/components/course/calendar-col.tsx
@@ -15,6 +15,8 @@ type ScheduleItemData =
       schedule: ParsedCourse;
       span: number;
       color: string; // 课程的颜色
+      overlappingSchedules?: ParsedCourse[]; // 重叠的课程
+      isPartialOverlap?: boolean; // 是否是部分重叠
     }
   | {
       type: 'empty';
@@ -29,6 +31,20 @@ interface CalendarColProps {
   onSyllabusPress: (syllabus: string) => void; // 教学大纲点击事件
   onLessonPlanPress: (lessonPlan: string) => void; // 授课计划点击事件
 }
+
+// 移除重复的课程，之所以需要这个，是因为教务处会莫名其妙安排完全一样的课程在教务处的课程表中，导致大量的重复课程显示
+const removeDuplicateSchedules = (schedules: ParsedCourse[]): ParsedCourse[] => {
+  const seen = new Set<string>();
+  return schedules.filter(schedule => {
+    // 将课程的唯一标识组合为一个字符串，例如 "课程名+教师+开始时间+结束时间+开始周数+结束周数"
+    const identifier = `${schedule.name}-${schedule.teacher}-${schedule.startClass}-${schedule.endClass}-${schedule.startWeek}-${schedule.endWeek}`;
+    if (seen.has(identifier)) {
+      return false; // 如果已经存在，则过滤掉
+    }
+    seen.add(identifier); // 如果不存在，则添加到集合中
+    return true;
+  });
+};
 
 // 课程表的一列，即一天的课程
 const CalendarCol: React.FC<CalendarColProps> = ({
@@ -45,27 +61,42 @@ const CalendarCol: React.FC<CalendarColProps> = ({
   // 根据当前周数和星期几，筛选出当天的课程
   // 并进行整合，生成一个用于渲染的数据结构
   const scheduleData = useMemo(() => {
-    const schedulesOnDay = schedules.filter(schedule => schedule.weekday === weekday);
+    // 筛选出当前星期几的课程
+    let schedulesOnDay = schedules.filter(schedule => schedule.weekday === weekday);
+
+    // 对课程进行去重
+    schedulesOnDay = removeDuplicateSchedules(schedulesOnDay);
+
     const res: ScheduleItemData[] = [];
 
     for (let i = 1; i <= 11; i++) {
-      // 查找当前时间段是否有课程，对于第二个参数，如果 isShowNonCurrentWeekCourses 为 true，则不限制周数
-      const schedule = schedulesOnDay.find(
-        s => s.startClass === i && (isShowNonCurrentWeekCourses || (s.startWeek <= week && s.endWeek >= week)),
+      // 找出当前时间段的所有课程
+      const overlappingSchedules = schedulesOnDay.filter(
+        s =>
+          s.startClass <= i &&
+          s.endClass >= i && // 当前时间段是否在课程时间范围内
+          (isShowNonCurrentWeekCourses || (s.startWeek <= week && s.endWeek >= week)), // 是否符合周数条件
       );
 
-      if (schedule) {
-        const span = schedule.endClass - schedule.startClass + 1;
+      if (overlappingSchedules.length > 0) {
+        const primarySchedule = overlappingSchedules[0]; // 默认取第一个课程为主课程
+        const span = primarySchedule.endClass - primarySchedule.startClass + 1;
+
         res.push({
           type: 'course',
-          schedule,
+          schedule: primarySchedule,
           span,
           color:
-            isShowNonCurrentWeekCourses && (schedule.startWeek > week || schedule.endWeek < week)
-              ? nonCurrentWeekCourses // 非本周课程不显示颜色，这样展示时是一个边框
-              : courseColorMap[schedule.syllabus], // 从课程颜色映射中获取颜色
+            isShowNonCurrentWeekCourses && (primarySchedule.startWeek > week || primarySchedule.endWeek < week)
+              ? nonCurrentWeekCourses
+              : courseColorMap[primarySchedule.syllabus],
+          overlappingSchedules: overlappingSchedules.length > 1 ? overlappingSchedules : undefined, // 如果有重叠课程，存储重叠课程信息
+          isPartialOverlap: overlappingSchedules.some(
+            s => s.startClass !== primarySchedule.startClass || s.endClass !== primarySchedule.endClass,
+          ), // 是否存在部分重叠
         });
-        i += span - 1;
+
+        i += span - 1; // 跳过当前课程的跨度
       } else {
         res.push({ type: 'empty' });
       }
@@ -89,6 +120,8 @@ const CalendarCol: React.FC<CalendarColProps> = ({
             span={item.span}
             color={item.color}
             schedule={item.schedule}
+            overlappingSchedules={item.overlappingSchedules}
+            isPartialOverlap={item.isPartialOverlap}
             onSyllabusPress={onSyllabusPress}
             onLessonPlanPress={onLessonPlanPress}
           />

--- a/components/course/calendar-col.tsx
+++ b/components/course/calendar-col.tsx
@@ -90,10 +90,12 @@ const CalendarCol: React.FC<CalendarColProps> = ({
             isShowNonCurrentWeekCourses && (primarySchedule.startWeek > week || primarySchedule.endWeek < week)
               ? nonCurrentWeekCourses
               : courseColorMap[primarySchedule.syllabus],
-          overlappingSchedules: overlappingSchedules.length > 1 ? overlappingSchedules : undefined, // 如果有重叠课程，存储重叠课程信息
+          // 如果有重叠课程，存储重叠课程信息
+          overlappingSchedules: overlappingSchedules.length > 1 ? overlappingSchedules : undefined,
+          // 是否存在部分重叠
           isPartialOverlap: overlappingSchedules.some(
             s => s.startClass !== primarySchedule.startClass || s.endClass !== primarySchedule.endClass,
-          ), // 是否存在部分重叠
+          ),
         });
 
         i += span - 1; // 跳过当前课程的跨度

--- a/components/course/schedule-item.tsx
+++ b/components/course/schedule-item.tsx
@@ -79,21 +79,21 @@ const ScheduleItem: React.FC<ScheduleItemProps> = ({
               backgroundColor: `${color}33`,
             }}
           >
-            <Text className="truncate text-wrap break-all text-center text-[11px] font-bold text-gray-500">
+            <Text className="truncate text-wrap break-all text-center text-[11px] font-bold text-muted-foreground">
               {schedule.name}
             </Text>
-            <Text className="text-wrap break-all text-[11px] text-gray-500">{schedule.location}</Text>
+            <Text className="text-wrap break-all text-[11px] text-muted-foreground">{schedule.location}</Text>
             {overlappingSchedules && overlappingSchedules.length > 1 && (
               <Pressable
                 onPress={() => setIsOverlapDialogOpen(true)} // 打开重叠课程弹窗
                 className="mt-1 flex flex-row items-center justify-center"
               >
-                <Text className="text-xs font-bold text-blue-500">有重叠</Text>
+                <Text className="text-xs font-bold text-primary">有重叠</Text>
               </Pressable>
             )}
             {isPartialOverlap && (
               <Text
-                className="text-warning mt-1 text-xs"
+                className="mt-1 text-xs text-destructive"
                 onPress={() => setIsPartialOverlapDialogOpen(true)} // 打开遮挡课程弹窗
               >
                 有遮挡
@@ -130,7 +130,7 @@ const ScheduleItem: React.FC<ScheduleItemProps> = ({
               </DescriptionListTerm>
               <DescriptionListDescription>
                 <Text>
-                  {schedule.startClass}-{schedule.endClass} 节({getTimeRange(schedule.startClass, schedule.endClass)})
+                  {schedule.startClass}-{schedule.endClass} 节 ({getTimeRange(schedule.startClass, schedule.endClass)})
                 </Text>
               </DescriptionListDescription>
             </DescriptionListRow>

--- a/components/course/schedule-item.tsx
+++ b/components/course/schedule-item.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Text } from '@/components/ui/text';
+import { CLASS_SCHEDULES } from '@/lib/constants';
 
 interface ScheduleItemProps {
   schedule: {
@@ -24,6 +25,19 @@ interface ScheduleItemProps {
     syllabus: string;
     lessonplan: string;
   };
+  overlappingSchedules?: {
+    name: string;
+    location: string;
+    teacher: string;
+    startClass: number;
+    endClass: number;
+    startWeek: number;
+    endWeek: number;
+    remark?: string;
+    syllabus: string;
+    lessonplan: string;
+  }[]; // 重叠的课程
+  isPartialOverlap?: boolean; // 是否部分重叠
   height: number;
   span: number;
   color: string; // 课程的颜色
@@ -31,111 +45,240 @@ interface ScheduleItemProps {
   onLessonPlanPress: (lessonPlan: string) => void; // 授课计划点击事件
 }
 
+// 根据节数获取时间范围
+const getTimeRange = (startClass: number, endClass: number): string => {
+  const startTime = CLASS_SCHEDULES[startClass - 1][0];
+  const endTime = CLASS_SCHEDULES[endClass - 1][1];
+  return `${startTime} - ${endTime}`;
+};
+
 const ScheduleItem: React.FC<ScheduleItemProps> = ({
   schedule,
   height,
   span,
   color,
+  overlappingSchedules,
+  isPartialOverlap,
   onSyllabusPress,
   onLessonPlanPress,
 }) => {
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false); // 控制课程详情弹窗
+  const [isOverlapDialogOpen, setIsOverlapDialogOpen] = useState(false); // 控制重叠课程弹窗
+  const [isPartialOverlapDialogOpen, setIsPartialOverlapDialogOpen] = useState(false); // 控制遮挡课程弹窗
 
   return (
-    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-      {/* 课程表中的一个课程，我们将每个课程作为打开课程详情的按钮 */}
-      <DialogTrigger asChild>
-        <Pressable
-          className="flex min-h-14 flex-shrink-0 flex-grow-0 basis-0 flex-col items-center justify-center rounded-lg border p-[1px]"
-          style={{
-            flexGrow: span,
-            height: (span / 11) * height,
-            borderColor: color, // 使用传入的颜色作为边框颜色
-            backgroundColor: `${color}33`, // 使用传入颜色的透明版本（33 表示约 20% 不透明度）
-          }}
-        >
-          <Text className="truncate text-wrap break-all text-center text-[11px] font-bold text-gray-500">
-            {schedule.name}
-          </Text>
-          <Text className="text-wrap break-all text-[11px] text-gray-500">{schedule.location}</Text>
-        </Pressable>
-      </DialogTrigger>
-
-      {/* 点击课程后弹出的 Dialog 内容 */}
-      <DialogContent className="flex w-[90vw] flex-col justify-center pb-6 pt-10 sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle className="text-center text-primary">{schedule.name}</DialogTitle>
-        </DialogHeader>
-
-        <DescriptionList className="mx-6 mb-1 mt-4">
-          <DescriptionListRow>
-            <DescriptionListTerm>
-              <Text>教室</Text>
-            </DescriptionListTerm>
-            <DescriptionListDescription>
-              <Text>{schedule.location}</Text>
-            </DescriptionListDescription>
-          </DescriptionListRow>
-          <DescriptionListRow>
-            <DescriptionListTerm>
-              <Text>教师</Text>
-            </DescriptionListTerm>
-            <DescriptionListDescription>
-              <Text>{schedule.teacher}</Text>
-            </DescriptionListDescription>
-          </DescriptionListRow>
-          <DescriptionListRow>
-            <DescriptionListTerm>
-              <Text>节数</Text>
-            </DescriptionListTerm>
-            <DescriptionListDescription>
-              <Text>
-                {schedule.startClass}-{schedule.endClass} 节
-              </Text>
-            </DescriptionListDescription>
-          </DescriptionListRow>
-          <DescriptionListRow>
-            <DescriptionListTerm>
-              <Text>周数</Text>
-            </DescriptionListTerm>
-            <DescriptionListDescription>
-              <Text>
-                {schedule.startWeek}-{schedule.endWeek} 周
-              </Text>
-            </DescriptionListDescription>
-          </DescriptionListRow>
-          <DescriptionListRow>
-            <DescriptionListTerm>
-              <Text>备注</Text>
-            </DescriptionListTerm>
-            <DescriptionListDescription>
-              <Text>{schedule.remark}</Text>
-            </DescriptionListDescription>
-          </DescriptionListRow>
-        </DescriptionList>
-
-        <View className="flex flex-row justify-evenly">
-          <Button
-            variant="link"
-            onPress={() => {
-              setIsDialogOpen(false);
-              onSyllabusPress(schedule.syllabus);
+    <>
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogTrigger asChild>
+          <Pressable
+            className="flex min-h-14 flex-shrink-0 flex-grow-0 basis-0 flex-col items-center justify-center rounded-lg border p-[1px]"
+            style={{
+              flexGrow: span,
+              height: (span / 11) * height,
+              borderColor: color,
+              backgroundColor: `${color}33`,
             }}
           >
-            <Text className="text-primary">教学大纲</Text>
-          </Button>
-          <Button
-            variant="link"
-            onPress={() => {
-              setIsDialogOpen(false);
-              onLessonPlanPress(schedule.lessonplan);
-            }}
-          >
-            <Text className="text-primary">授课计划</Text>
-          </Button>
-        </View>
-      </DialogContent>
-    </Dialog>
+            <Text className="truncate text-wrap break-all text-center text-[11px] font-bold text-gray-500">
+              {schedule.name}
+            </Text>
+            <Text className="text-wrap break-all text-[11px] text-gray-500">{schedule.location}</Text>
+            {overlappingSchedules && overlappingSchedules.length > 1 && (
+              <Pressable
+                onPress={() => setIsOverlapDialogOpen(true)} // 打开重叠课程弹窗
+                className="mt-1 flex flex-row items-center justify-center"
+              >
+                <Text className="text-xs font-bold text-blue-500">有重叠</Text>
+              </Pressable>
+            )}
+            {isPartialOverlap && (
+              <Text
+                className="text-warning mt-1 text-xs"
+                onPress={() => setIsPartialOverlapDialogOpen(true)} // 打开遮挡课程弹窗
+              >
+                有遮挡
+              </Text>
+            )}
+          </Pressable>
+        </DialogTrigger>
+
+        <DialogContent className="flex w-[90vw] flex-col justify-center pb-6 pt-10 sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle className="text-center text-primary">{schedule.name}</DialogTitle>
+          </DialogHeader>
+
+          <DescriptionList className="mx-6 mb-1 mt-4">
+            <DescriptionListRow>
+              <DescriptionListTerm>
+                <Text>教室</Text>
+              </DescriptionListTerm>
+              <DescriptionListDescription>
+                <Text>{schedule.location}</Text>
+              </DescriptionListDescription>
+            </DescriptionListRow>
+            <DescriptionListRow>
+              <DescriptionListTerm>
+                <Text>教师</Text>
+              </DescriptionListTerm>
+              <DescriptionListDescription>
+                <Text>{schedule.teacher}</Text>
+              </DescriptionListDescription>
+            </DescriptionListRow>
+            <DescriptionListRow>
+              <DescriptionListTerm>
+                <Text>节数</Text>
+              </DescriptionListTerm>
+              <DescriptionListDescription>
+                <Text>
+                  {schedule.startClass}-{schedule.endClass} 节({getTimeRange(schedule.startClass, schedule.endClass)})
+                </Text>
+              </DescriptionListDescription>
+            </DescriptionListRow>
+            <DescriptionListRow>
+              <DescriptionListTerm>
+                <Text>周数</Text>
+              </DescriptionListTerm>
+              <DescriptionListDescription>
+                <Text>
+                  {schedule.startWeek}-{schedule.endWeek} 周
+                </Text>
+              </DescriptionListDescription>
+            </DescriptionListRow>
+            <DescriptionListRow>
+              <DescriptionListTerm>
+                <Text>备注</Text>
+              </DescriptionListTerm>
+              <DescriptionListDescription>
+                <Text>{schedule.remark}</Text>
+              </DescriptionListDescription>
+            </DescriptionListRow>
+          </DescriptionList>
+
+          <View className="flex flex-row justify-evenly">
+            <Button
+              variant="link"
+              onPress={() => {
+                setIsDialogOpen(false);
+                onSyllabusPress(schedule.syllabus);
+              }}
+            >
+              <Text className="text-primary">教学大纲</Text>
+            </Button>
+            <Button
+              variant="link"
+              onPress={() => {
+                setIsDialogOpen(false);
+                onLessonPlanPress(schedule.lessonplan);
+              }}
+            >
+              <Text className="text-primary">授课计划</Text>
+            </Button>
+          </View>
+        </DialogContent>
+      </Dialog>
+
+      {/* 重叠课程弹窗 */}
+      {overlappingSchedules && overlappingSchedules.length > 1 && (
+        <Dialog open={isOverlapDialogOpen} onOpenChange={setIsOverlapDialogOpen}>
+          <DialogContent className="flex w-[90vw] flex-col justify-center pb-6 pt-10 sm:max-w-[425px]">
+            <DialogHeader>
+              <DialogTitle className="text-center text-primary">重叠课程</DialogTitle>
+            </DialogHeader>
+            {overlappingSchedules.map((overlap, index) => (
+              <DescriptionList key={index} className="mx-6 mb-2">
+                <DescriptionListRow>
+                  <DescriptionListTerm>
+                    <Text>课程名</Text>
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <Text>{overlap.name}</Text>
+                  </DescriptionListDescription>
+                </DescriptionListRow>
+                <DescriptionListRow>
+                  <DescriptionListTerm>
+                    <Text>教室</Text>
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <Text>{overlap.location}</Text>
+                  </DescriptionListDescription>
+                </DescriptionListRow>
+                <DescriptionListRow>
+                  <DescriptionListTerm>
+                    <Text>教师</Text>
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <Text>{overlap.teacher}</Text>
+                  </DescriptionListDescription>
+                </DescriptionListRow>
+                <DescriptionListRow>
+                  <DescriptionListTerm>
+                    <Text>节数</Text>
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <Text>
+                      {overlap.startClass}-{overlap.endClass} 节 ({getTimeRange(overlap.startClass, overlap.endClass)})
+                    </Text>
+                  </DescriptionListDescription>
+                </DescriptionListRow>
+                <DescriptionListRow>
+                  <DescriptionListTerm>
+                    <Text>周数</Text>
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <Text>
+                      {overlap.startWeek}-{overlap.endWeek} 周
+                    </Text>
+                  </DescriptionListDescription>
+                </DescriptionListRow>
+              </DescriptionList>
+            ))}
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {/* 遮挡课程弹窗 */}
+      {isPartialOverlap && (
+        <Dialog open={isPartialOverlapDialogOpen} onOpenChange={setIsPartialOverlapDialogOpen}>
+          <DialogContent className="flex w-[90vw] flex-col justify-center pb-6 pt-10 sm:max-w-[425px]">
+            <DialogHeader>
+              <DialogTitle className="text-warning text-center text-primary">遮挡课程详情</DialogTitle>
+            </DialogHeader>
+            {overlappingSchedules &&
+              overlappingSchedules.map((overlap, index) => (
+                <DescriptionList key={index} className="mx-6 mb-2">
+                  <DescriptionListRow>
+                    <DescriptionListTerm>
+                      <Text>课程名</Text>
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <Text>{overlap.name}</Text>
+                    </DescriptionListDescription>
+                  </DescriptionListRow>
+                  <DescriptionListRow>
+                    <DescriptionListTerm>
+                      <Text>时间</Text>
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <Text>
+                        第 {overlap.startClass}-{overlap.endClass} 节 (
+                        {getTimeRange(overlap.startClass, overlap.endClass)})
+                      </Text>
+                    </DescriptionListDescription>
+                  </DescriptionListRow>
+                  <DescriptionListRow>
+                    <DescriptionListTerm>
+                      <Text>教室</Text>
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <Text>{overlap.location}</Text>
+                    </DescriptionListDescription>
+                  </DescriptionListRow>
+                </DescriptionList>
+              ))}
+          </DialogContent>
+        </Dialog>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
当前课表的显示会出现遮盖，这个问题同样出现在我们目前正在运行的 fzuhelper-iOS 中。

> 需要注意的是，这个需求本质是个小众需求，对于降级、转专业、辅修的学生较为重要，对于大部分的学生而言不会出现课程重叠的问题（或者重叠只发生在开启`显示非本周课程`的情况下）

这个 pr 负责解决课程重叠问题，本质上是给教务处擦屁股，目前设计如下

1. 重新调整课程排课方案，具体如下

- 接收到完整的本学期课程数据（`calendar-col.tsx`中的`schedules`）
- 对课程进行去重（教务处在过往的学期排课中出现了完全一模一样的排课排 2 次的情况）
- 创建`occupiedSlots`用于记录已经被安排的时间段。
- 我们优先安排短期（即标准的 2 小时课程或更短课程）且所处的上课时间没有其他课程占用的课程（用于显示）。
- 我们再安排其余课程（如有）到被遮挡课程（`partiallyOverlappingSchedules`，指部分课程和显示课程重叠）中或重叠课程（`fullyOverlappingSchedules`，指课程完全被遮住）
- 渲染时对于含有被遮挡和被重叠的课程提供`有遮挡`和`有重叠`两个入口，按下后可以查看具体的课程

参考图片：
![649f47c4b7ff680a47cb50eef6877a54](https://github.com/user-attachments/assets/11593306-a727-4f91-86cd-a5075d36593f)
![414501f59e5e799ce286eff8f44377f2](https://github.com/user-attachments/assets/3642848a-700a-409c-bf56-1dc15a1b5529)
![4b96638323cf365d7229ced8002ea99d](https://github.com/user-attachments/assets/2946c2fd-1c35-40a0-9298-b2594a23fe73)
