### PR TITLE
fix: android crash caused by okhttp version conflict

### DIFF
--- a/modules/native-request/android/build.gradle
+++ b/modules/native-request/android/build.gradle
@@ -43,7 +43,8 @@ android {
 }
 
 dependencies {
-    // 解决请求很慢的问题 (fastFallback)
-    implementation('com.squareup.okhttp3:okhttp:5.0.0-alpha.14')
+    // https://github.com/facebook/react-native/blob/main/packages/react-native/gradle/libs.versions.toml#L31
+    // 此版本不支持 Fast Fallback，为避免依赖冲突闪退而暂时使用
+    implementation('com.squareup.okhttp3:okhttp:4.9.2')
     implementation('com.google.code.gson:gson:2.11.0')
 }

--- a/modules/native-request/android/src/main/java/com/west2online/nativerequest/NativeRequestModule.kt
+++ b/modules/native-request/android/src/main/java/com/west2online/nativerequest/NativeRequestModule.kt
@@ -99,7 +99,7 @@ class NativeRequestModule : Module() {
                 val response = client.newCall(request).execute()
                 resp.status = response.code
                 resp.headers = response.headers.toMap()
-                resp.data = response.body.bytes()
+                resp.data = response.body?.bytes()
             } catch (e: Exception) {
                 resp.error = "请求失败: ${e.message}"
             }
@@ -129,7 +129,7 @@ class NativeRequestModule : Module() {
                 val response = client.newCall(request).execute()
                 resp.status = response.code
                 resp.headers = response.headers.toMap()
-                resp.data = response.body.bytes()
+                resp.data = response.body?.bytes()
             } catch (e: Exception) {
                 resp.error = "请求失败: ${e.message}"
             }
@@ -158,7 +158,7 @@ class NativeRequestModule : Module() {
                 val response = client.newCall(request).execute()
                 resp.status = response.code
                 resp.headers = response.headers.toMap()
-                resp.data = response.body.bytes()
+                resp.data = response.body?.bytes()
             } catch (e: Exception) {
                 resp.error = "请求失败: ${e.message}"
             }


### PR DESCRIPTION
native-request模块中使用的okhttp版本为5.0.0-alpha.14，主要为了支持Fast Fallback特性。测试发现由未知触发条件导致闪退，排查发现RN目前使用的版本为4.9.2，两个版本混用导致了一定冲突。

https://github.com/facebook/react-native/blob/main/packages/react-native/gradle/libs.versions.toml#L31

由于假期内教务处已完成IPv6适配，理论上不会再触发访问缓慢问题，因此暂时降级模块中okhttp版本到4.9.2。等待okhttp发布正式版、RN升级后做同步更新。https://github.com/facebook/react-native/issues/32730 https://github.com/square/okhttp/issues/506#issuecomment-1227325306

stacktrace:
```
java.lang.NoClassDefFoundError: Failed resolution of: Lokhttp3/internal/Util;
	at okhttp3.JavaNetCookieJar.decodeHeaderAsJavaNetCookies(JavaNetCookieJar.kt:81)
	at okhttp3.JavaNetCookieJar.loadForRequest(JavaNetCookieJar.kt:59)
	at com.facebook.react.modules.network.ReactCookieJarContainer.loadForRequest(ReactCookieJarContainer.java:44)
	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:73)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:72)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:203)
	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:527)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
	at java.lang.Thread.run(Thread.java:1012)
Caused by: java.lang.ClassNotFoundException: Didn't find class "okhttp3.internal.Util" on path: DexPathList[[zip file "/data/app/~~mYzCpXOHoAGQ8-NG4tnfPA==/com.helper.west2ol.fzuhelper-d4Nr1HvVrUvHO0Svn7FwBg==/base.apk"],nativeLibraryDirectories=[/data/app/~~mYzCpXOHoAGQ8-NG4tnfPA==/com.helper.west2ol.fzuhelper-d4Nr1HvVrUvHO0Svn7FwBg==/lib/arm64, /data/app/~~mYzCpXOHoAGQ8-NG4tnfPA==/com.helper.west2ol.fzuhelper-d4Nr1HvVrUvHO0Svn7FwBg==/base.apk!/lib/arm64-v8a, /system/lib64, /system_ext/lib64]]
	at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:259)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:379)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:312)
	... 12 more
```