### PR TITLE
修复设置优先级后周数偏移问题

### DIFF
--- a/lib/course.ts
+++ b/lib/course.ts
@@ -416,11 +416,10 @@ export class CourseCache {
     const groupedData = extendedCourses.reduce(
       (result, current) => {
         const day = current.weekday - 1;
-        if (!result[day]) result[day] = [];
         result[day].push(current);
         return result;
       },
-      {} as Record<number, ExtendCourse[]>,
+      { 0: [], 1: [], 2: [], 3: [], 4: [], 5: [], 6: [] } as Record<number, ExtendCourse[]>,
     );
 
     // 更新缓存

--- a/lib/course.ts
+++ b/lib/course.ts
@@ -419,7 +419,7 @@ export class CourseCache {
         result[day].push(current);
         return result;
       },
-      { 0: [], 1: [], 2: [], 3: [], 4: [], 5: [], 6: [] } as Record<number, ExtendCourse[]>,
+      Object.fromEntries(Array.from({ length: 7 }, (_, i) => [i, []])) as Record<number, ExtendCourse[]>,
     );
 
     // 更新缓存


### PR DESCRIPTION
```
    const updatedData = Object.values(this.cachedData).map(day =>
```
这个day是index，预期正好对应一周的0-6，但416行开始的reduce函数并未在初始化时分配0-6，当某天完全无课时，result的key可能中间有空缺，在上述代码执行时就会产生偏移。

已存在的错乱数据可通过切换学期恢复。