### PR TITLE
居中页面标题，使跨端行为统一

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -68,7 +68,7 @@ export default function TabLayout() {
   }, [handleError]);
 
   return (
-    <Tabs>
+    <Tabs screenOptions={{ headerTitleAlign: 'center' }}>
       <Tabs.Screen
         name="index"
         options={{

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout() {
         <ThemeProvider value={currentColorScheme === 'dark' ? DarkTheme : DefaultTheme}>
           <KeyboardProvider>
             <GestureHandlerRootView>
-              <Stack screenOptions={{ animation: 'ios_from_right' }}>
+              <Stack screenOptions={{ animation: 'ios_from_right', headerTitleAlign: 'center' }}>
                 <Stack.Screen name="/(guest)" />
                 <Stack.Screen name="+not-found" />
               </Stack>

--- a/app/common/academic-calendar.tsx
+++ b/app/common/academic-calendar.tsx
@@ -142,12 +142,7 @@ export default function AcademicCalendarPage() {
 
   return (
     <>
-      <Stack.Screen
-        options={{
-          headerTitleAlign: 'center',
-          headerTitle: '学期校历',
-        }}
-      />
+      <Stack.Screen options={{ title: '学期校历' }} />
 
       <PageContainer>
         <TabFlatList data={termList} value={currentTerm} onChange={setCurrentTerm} renderContent={renderContent} />

--- a/app/toolbox/academic/credits.tsx
+++ b/app/toolbox/academic/credits.tsx
@@ -51,7 +51,8 @@ export default function CreditsPage() {
 
   return (
     <>
-      <Stack.Screen options={{ headerTitle: '学分统计' }} />
+      <Stack.Screen options={{ title: '学分统计' }} />
+
       {isRefreshing ? (
         <Loading />
       ) : (

--- a/app/toolbox/academic/grades.tsx
+++ b/app/toolbox/academic/grades.tsx
@@ -145,8 +145,7 @@ export default function GradesPage() {
     <>
       <Tabs.Screen
         options={{
-          headerTitleAlign: 'center',
-          headerTitle: '成绩查询',
+          title: '成绩查询',
           // eslint-disable-next-line react/no-unstable-nested-components
           headerRight: () => (
             <Pressable onPress={handleModalVisible} className="flex flex-row items-center">

--- a/app/toolbox/exam-room.tsx
+++ b/app/toolbox/exam-room.tsx
@@ -173,8 +173,7 @@ export default function ExamRoomPage() {
     <>
       <Stack.Screen
         options={{
-          headerTitleAlign: 'center',
-          headerTitle: '考场查询',
+          title: '考场查询',
           // eslint-disable-next-line react/no-unstable-nested-components
           headerRight: () => (
             <Pressable onPress={handleModalVisible} className="flex flex-row items-center">

--- a/components/course/course-page.tsx
+++ b/components/course/course-page.tsx
@@ -178,7 +178,6 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
       {/* 顶部 Tab 导航栏 */}
       <Tabs.Screen
         options={{
-          headerTitleAlign: 'center',
           // eslint-disable-next-line react/no-unstable-nested-components
           headerLeft: () => <Text className="ml-4 text-2xl font-medium">课程表</Text>,
           // eslint-disable-next-line react/no-unstable-nested-components


### PR DESCRIPTION
Android 端默认的页面标题居左，iOS 则是居中，且目前现有的页面也存在居左和居中混用的情况。此提交调整了页面标题的对齐方式，使得标题全部居中。