### PR TITLE
修正存在补考课程时的学期 GPA 计算

### DIFF
--- a/app/toolbox/academic/grades.tsx
+++ b/app/toolbox/academic/grades.tsx
@@ -1,5 +1,5 @@
 import { Tabs } from 'expo-router';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Dimensions, Pressable, RefreshControl, ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { toast } from 'sonner-native';
@@ -41,8 +41,8 @@ const TermContent: React.FC<TermContentProps> = ({ term, onRefresh }) => {
     refetch,
   } = useApiRequest(getApiV1JwchAcademicScores, {}, { errorHandler });
   const lastUpdated = new Date(dataUpdatedAt);
-  const filteredData = (academicData ?? []).filter(it => it.term === term);
-  const summary = calSingleTermSummary(filteredData, term);
+  const filteredData = useMemo(() => (academicData ?? []).filter(it => it.term === term), [academicData, term]);
+  const summary = useMemo(() => calSingleTermSummary(filteredData), [filteredData]);
 
   return (
     <ScrollView


### PR DESCRIPTION
将学期内补考课程对应的原课程成绩排除后再计算 GPA，与教务系统保持一致。

注：对于重修课程，在计算学期绩点时没有排除原课程信息。

---

This PR fixes the GPA calculation for semesters with re‐examination courses by excluding the original course grade when a corresponding re‐examination grade is available. Key changes include:

- Refactoring the GPA calculation in lib/grades.ts to filter out original grades if a re‐examination course exists with a valid GPA.
- Introducing helper functions removeReexaminationCourse and getGpaRelevantData to modularize filtering logic.
- Updating memoization in app/toolbox/academic/grades.tsx to optimize filtering and recalculation when academic data or term changes.