### PR TITLE
支持 iOS Live Activity 提示下一节课上什么

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -39,6 +39,8 @@ const config: ExpoConfig = {
       NSAppTransportSecurity: {
         NSAllowsArbitraryLoads: true, // 允许访问非 HTTPS 的内容
       },
+      NSSupportsLiveActivities: true, // 支持 Live Activity
+      NSSupportsLiveActivitiesFrequentUpdates: true, // 支持 Live Activity 频繁更新
     },
     entitlements: {
       'com.apple.security.application-groups': ['group.FzuHelper.NextCourse'],

--- a/inject-ios-prebuild.ts
+++ b/inject-ios-prebuild.ts
@@ -1,9 +1,16 @@
 import { ExpoConfig } from 'expo/config';
-import { withDangerousMod } from 'expo/config-plugins';
+import { withDangerousMod, withXcodeProject } from 'expo/config-plugins';
 import { promises as fs } from 'fs';
 import { join, resolve } from 'path';
 
 function withIOSInject(config: ExpoConfig): ExpoConfig {
+  // 侵入项目，配置 Build Settings
+  config = withXcodeProject(config, xcodeConfig => {
+    const project = xcodeConfig.modResults;
+    // 配置 Build Settings ，以支持 Live Activity
+    return xcodeConfig;
+  });
+
   // 修改 Info.plist 文件可以直接通过 app.config.ts 完成
   // 通过 withDangerousMod 注入 iOS 脚本
   config = withDangerousMod(config, [

--- a/targets/iOS-widget/AppIntent.swift
+++ b/targets/iOS-widget/AppIntent.swift
@@ -9,10 +9,16 @@ struct ConfigurationAppIntent: WidgetConfigurationIntent {
   // 上次更新时间
   @Parameter(title: "显示上次更新时间", default: true)
   var showLastUpdateTime: Bool
+  
+  // 上课前 30 分钟激活 LiveActivity（实时活动）
+  @Parameter(title: "上课前30分钟激活实时活动", default: true)
+  var enableLiveActivity: Bool
 
   static var parameterSummary: some ParameterSummary {
-    Summary("显示上次更新时间") {
+    Summary("编辑小组件配置") {
       \.$showLastUpdateTime
+      \.$enableLiveActivity
     }
+    
   }
 }

--- a/targets/iOS-widget/Info.plist
+++ b/targets/iOS-widget/Info.plist
@@ -7,5 +7,9 @@
       <key>NSExtensionPointIdentifier</key>
       <string>com.apple.widgetkit-extension</string>
     </dict>
+    <key>NSSupportsLiveActivities</key>
+    <true/>
+    <key>NSSupportsLiveActivitiesFrequentUpdates</key>
+    <true/>
   </dict>
 </plist>

--- a/targets/iOS-widget/LiveActivity.swift
+++ b/targets/iOS-widget/LiveActivity.swift
@@ -1,0 +1,185 @@
+//
+//  LiveActivity.swift
+//  fzuhelper
+//
+//  Created by 黄骁 on 2025/3/14.
+//
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+// MARK: 定义 Live Activity 的属性和动态状态
+struct NextCourseActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        // 动态状态：下一节课的相关信息
+        var courseName: String      // 课程名称
+        var courseLocation: String  // 地点
+        var courseWeekday: String   // 星期
+        var courseSection: String   // 节数
+    }
+
+    // 固定属性：活动名称
+    var name: String
+}
+
+// MARK: 定义 Live Activity 的实现
+struct NextCourseLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: NextCourseActivityAttributes.self) { context in
+            // 锁屏和横幅通知的 UI
+            VStack(alignment: .leading) {
+                Text("即将上课")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                Text(context.state.courseName)
+                    .font(.title2)
+                    .bold()
+                    .foregroundColor(.white)
+                Text("地点: \(context.state.courseLocation)")
+                    .font(.subheadline)
+                    .foregroundColor(.white.opacity(0.8))
+                Text("\(context.state.courseWeekday) \(context.state.courseSection)")
+                    .font(.subheadline)
+                    .foregroundColor(.white.opacity(0.8))
+            }
+            .padding()
+            .activityBackgroundTint(Color.blue) // 设置背景颜色
+            .activitySystemActionForegroundColor(Color.white) // 设置前景颜色
+
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // 展开状态的 UI
+                DynamicIslandExpandedRegion(.center) {
+                    VStack(alignment: .leading) {
+                        Text("即将上课")
+                            .font(.headline)
+                            .foregroundColor(.white)
+                        Text(context.state.courseName)
+                            .font(.title3)
+                            .bold()
+                            .foregroundColor(.white)
+                        Text("地点: \(context.state.courseLocation)")
+                            .font(.subheadline)
+                            .foregroundColor(.white.opacity(0.8))
+                        Text("\(context.state.courseWeekday) \(context.state.courseSection)")
+                            .font(.subheadline)
+                            .foregroundColor(.white.opacity(0.8))
+                    }
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text("上课前 1 小时提醒")
+                        .font(.footnote)
+                        .foregroundColor(.white.opacity(0.7))
+                }
+            } compactLeading: {
+                Text("课")
+                    .font(.headline)
+                    .foregroundColor(.white)
+            } compactTrailing: {
+                Text(context.state.courseName.prefix(3)) // 只显示课程名称的前三个字符
+                    .font(.headline)
+                    .foregroundColor(.white)
+            } minimal: {
+                Text("课")
+                    .font(.headline)
+                    .foregroundColor(.white)
+            }
+            .widgetURL(URL(string: "fzuhelper://next-course")) // 点击跳转到 App 的 URL Scheme
+            .keylineTint(Color.blue)
+        }
+    }
+}
+
+// 启动 Live Activity 的逻辑
+func startNextCourseLiveActivity(nextClass: ClassInfo, currentWeek: Int) {
+    // 检查当前时间是否需要启动 Live Activity
+    guard let startTime = calculateClassStartTime(nextClass: nextClass) else { return }
+    let now = Date()
+    let timeUntilStart = startTime.timeIntervalSince(now)
+
+//    // 如果距离上课时间超过 1 小时或已经过了上课时间，则不启动
+//    if timeUntilStart > 36000 || timeUntilStart < -3600 {
+//        return
+//    }
+
+    // 定义 Live Activity 的属性和动态状态
+    let attributes = NextCourseActivityAttributes(name: "下一节课提醒")
+    let contentState = NextCourseActivityAttributes.ContentState(
+        courseName: nextClass.courseBean.name,
+        courseLocation: nextClass.courseBean.location,
+        courseWeekday: "周\(getWeekChinese(nextClass.courseBean.weekday))",
+        courseSection: "\(nextClass.courseBean.startClass)-\(nextClass.courseBean.endClass)节"
+    )
+  
+    // 创建 ActivityContent，期望是课前 30 分钟和课后 60 分钟显示实时活动
+    let content = ActivityContent(
+        state: contentState,
+        staleDate: Calendar.current
+          .date(
+            byAdding: .minute,
+            value: 90,
+            to: Date()
+          ) // 设置过期时间为 1.5 小时
+    )
+
+    // 启动 Live Activity
+    do {
+        let activity = try Activity<NextCourseActivityAttributes>.request(
+            attributes: attributes,
+            content: content,
+            pushType: .none
+        )
+        print("Live Activity 启动成功: \(activity.id)")
+    } catch {
+        print("Live Activity 启动失败: \(error)")
+    }
+}
+
+// 计算课程的开始时间
+func calculateClassStartTime(nextClass: ClassInfo) -> Date? {
+    let calendar = Calendar.current
+    let currentDate = Date()
+
+    // 根据课程的周几和节次计算开始时间
+    let weekday = nextClass.courseBean.weekday
+    guard let startHour = getHourForSection(nextClass.courseBean.startClass) else {
+        return nil
+    }
+
+    // 设置课程的开始日期和时间
+    var components = calendar.dateComponents([.year, .month, .day], from: currentDate)
+    components.weekday = weekday
+    components.hour = startHour
+    components.minute = 0
+
+    return calendar.date(from: components)
+}
+
+// 根据节次获取对应的小时
+func getHourForSection(_ section: Int) -> Int? {
+    switch section {
+    case 1: return 8
+    case 2: return 9
+    case 3: return 10
+    case 4: return 11
+    case 5: return 14
+    case 6: return 15
+    case 7: return 16
+    case 8: return 17
+    case 9: return 19
+    case 10: return 20
+    default: return nil
+    }
+}
+
+// 示例：在 Widget 的 Timeline 中调用 Live Activity
+func startLiveActivityIfNeeded(nextClass: ClassInfo?, startTime: TimeInterval?, currentWeek: Int) {
+    guard let nextClass = nextClass, let startTime = startTime else { return }
+
+    // 检查当前是否需要启动 Live Activity
+    let now = Date().timeIntervalSince1970
+    if startTime - now <= 36000 { // 距离上课时间小于等于 1 小时
+        startNextCourseLiveActivity(nextClass: nextClass, currentWeek: currentWeek)
+    }
+}

--- a/targets/iOS-widget/index.swift
+++ b/targets/iOS-widget/index.swift
@@ -6,5 +6,6 @@ struct exportWidgets: WidgetBundle {
   var body: some Widget {
     // 这里表示你会导出需要的 Widget，如果有其他 Widget，在这里导出即可
     widget()  // 普通 Widget，标准的桌面组件
+    NextCourseLiveActivity() // 带有实时活动的 LiveActivity
   }
 }

--- a/targets/iOS-widget/widgets.swift
+++ b/targets/iOS-widget/widgets.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import WidgetKit
+import ActivityKit
 
 // TimelineProvider 负责生成小组件的内容
 struct Provider: AppIntentTimelineProvider {
@@ -126,6 +127,24 @@ struct Provider: AppIntentTimelineProvider {
         notCurrentWeek: nextClass.week != currentWeek
       )
       entries.append(entry)
+      
+      
+      // MARK: 额外的 LiveActivity 功能
+      // 检查是否需要启动 LiveActivity
+      if let classStartTime = calculateClassStartTime(nextClass: nextClass) {
+        let timeUntilStart = classStartTime.timeIntervalSinceNow;
+        
+        // 返回的是秒，所以是 1800 秒（30 * 60）
+        if timeUntilStart <= 18000 && timeUntilStart > 0 {
+          // 如果符合条件，且没有启动过 Activity，则启动
+          if Activity<NextCourseActivityAttributes>.activities.isEmpty {
+            startNextCourseLiveActivity(
+              nextClass: nextClass,
+              currentWeek: currentWeek
+            );
+          }
+        }
+      }
     } else {
       // 数据正常，且没有下一节课，那么就是放假了
       let entryDate = Date()


### PR DESCRIPTION
> 留给后面的同学完成

这份代码实现了基础的 iOS Live Activity（iOS 17.2+）。

目前的逻辑是这样的：Widget 被系统唤醒进行 Refreshing 的时候（约 15-60min 唤醒一次）会判断距离下一节课还剩多久，如果是 0-30 分钟内，且先前没有唤醒过，则尝试启动 Live Activity。

但是调试过程中一直遇到 unsupportedTarget，查阅了一些资料，可以确定 Info.plist 等配置没有问题，唯一能解释的就是 Apple 禁止 Widget 自唤醒 LiveActivity（部分说明要求唤醒 LiveActivity 时 App 在前台）

鉴于后续重心不在这个项目上，我先提交这份在硬盘中的代码，留给后面的同学看看能不能完成。


另一个策略：参考[这份 demo](https://github.com/EvanBacon/expo-apple-targets/tree/main/apps/live-activities-demo)，利用 Expo Modules API 桥接 JS 和 Swift，实现 app 内调用 LiveActivity 唤醒。