### PR TITLE
Patch/250317

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -89,7 +89,12 @@ export default function HomePage() {
   // 具体加载课程的逻辑在 CoursePage 组件中
   return config && currentWeek && termsData ? (
     <PageContainer refreshBackground>
-      <CoursePage config={config} initialWeek={currentWeek} semesterList={termsData.data.data.terms} />
+      <CoursePage
+        config={config}
+        initialWeek={currentWeek}
+        semesterList={termsData.data.data.terms}
+        currentTerm={termsData.data.data.current_term}
+      />
     </PageContainer>
   ) : (
     <Loading />

--- a/components/course/course-page.tsx
+++ b/components/course/course-page.tsx
@@ -190,11 +190,22 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
           headerBackground: !customBackground ? () => <View className="flex-1 bg-card" /> : undefined,
           // headerStyle: { backgroundColor: customBackground ? 'transparent' :  },
           // eslint-disable-next-line react/no-unstable-nested-components
-          headerLeft: () => <Text className="ml-4 text-2xl font-medium">课程表</Text>,
+          headerLeft: () => (
+            <Pressable onPress={() => flatListRef.current?.scrollToIndex({ index: initialWeek - 1, animated: true })}>
+              <Text className="ml-4 text-2xl font-medium">课程表</Text>
+            </Pressable>
+          ),
           // eslint-disable-next-line react/no-unstable-nested-components
           headerTitle: () => (
             <Pressable onPress={() => setShowWeekSelector(!showWeekSelector)} className="flex flex-row items-center">
-              <Text className="mr-1 text-lg">第 {currentWeek} 周 </Text>
+              <Text className="mr-1 text-lg">
+                第 {currentWeek} 周{' '}
+                {currentWeek === initialWeek &&
+                new Date() >= new Date(currentSemester.start_date) &&
+                new Date() <= new Date(currentSemester.end_date)
+                  ? '(本周)'
+                  : ''}
+              </Text>
               <Icon name={showWeekSelector ? 'caret-up-outline' : 'caret-down-outline'} size={10} />
             </Pressable>
           ),

--- a/components/course/course-page.tsx
+++ b/components/course/course-page.tsx
@@ -192,7 +192,12 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
           // headerStyle: { backgroundColor: customBackground ? 'transparent' :  },
           // eslint-disable-next-line react/no-unstable-nested-components
           headerLeft: () => (
-            <Pressable onPress={() => flatListRef.current?.scrollToIndex({ index: initialWeek - 1, animated: true })}>
+            <Pressable
+              onPress={() => {
+                setCurrentWeek(initialWeek);
+                flatListRef.current?.scrollToIndex({ index: initialWeek - 1, animated: false });
+              }}
+            >
               <Text className="ml-4 text-2xl font-medium">课程表</Text>
             </Pressable>
           ),

--- a/components/course/course-page.tsx
+++ b/components/course/course-page.tsx
@@ -25,10 +25,11 @@ interface CoursePageProps {
   config: CourseSetting;
   initialWeek: number;
   semesterList: TermsListResponse_Terms;
+  currentTerm: string;
 }
 
 // 课程表页面
-const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterList }) => {
+const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterList, currentTerm }) => {
   const [currentWeek, setCurrentWeek] = useState(initialWeek); // 当前周数
   const [showWeekSelector, setShowWeekSelector] = useState(false);
   const { width } = useWindowDimensions(); // 获取屏幕宽度
@@ -199,12 +200,7 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
           headerTitle: () => (
             <Pressable onPress={() => setShowWeekSelector(!showWeekSelector)} className="flex flex-row items-center">
               <Text className="mr-1 text-lg">
-                第 {currentWeek} 周{' '}
-                {currentWeek === initialWeek &&
-                new Date() >= new Date(currentSemester.start_date) &&
-                new Date() <= new Date(currentSemester.end_date)
-                  ? '(本周)'
-                  : ''}
+                第 {currentWeek} 周 {currentWeek === initialWeek && currentTerm === term ? '(本周)' : ''}
               </Text>
               <Icon name={showWeekSelector ? 'caret-up-outline' : 'caret-down-outline'} size={10} />
             </Pressable>

--- a/components/tab-flatlist.tsx
+++ b/components/tab-flatlist.tsx
@@ -65,7 +65,13 @@ export function TabFlatList({
   return (
     <>
       <Tabs value={value} onValueChange={handleTabChange}>
-        <ScrollView horizontal showsHorizontalScrollIndicator={false} ref={tabsScrollViewRef}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          ref={tabsScrollViewRef}
+          overScrollMode="never"
+          bounces={false}
+        >
           <TabsList className="flex-row">
             {data.map((item, index) => (
               <TabsTrigger key={index} value={item} className="items-center" style={{ width: tabWidth }}>

--- a/targets/iOS-widget/widgets.swift
+++ b/targets/iOS-widget/widgets.swift
@@ -204,7 +204,7 @@ struct widgetEntryView: View {
                 Text(
                   (entry.notCurrentWeek ? "(非本周)" : "第 \(entry.courseWeek) 周")
                 )
-                .font(entry.notCurrentWeek ? .caption : .subheadline)
+                .font(.caption)
                 .foregroundColor(secondaryTextColor)
                 .lineLimit(1)
               }


### PR DESCRIPTION
- [x] 新增：在当前周后面备注（本周）
- [x] 新增：一键跳回本周功能（单击“课程表”）备注：非本学期单击会跳回第一周
- [x] 修复：tabflatlist标签切换时的动画问题
- [x] 修复：tabflatlist标签列表越界问题
- [x] 修复：iOS 屏保小组件字体显示问题