### PR TITLE
修正本地登录导致类型错误的因素

### DIFF
--- a/lib/user-login.ts
+++ b/lib/user-login.ts
@@ -82,13 +82,13 @@ class UserLogin {
     return Buffer.from(response).toString('utf-8').replace(/\s+/g, '');
   }
 
-  #checkErrors(data: string): string {
+  #checkErrors(data: string): string | null {
     for (const [key, message] of Object.entries(ERROR_MESSAGES)) {
       if (data.includes(key)) {
         return message;
       }
     }
-    return '未知错误';
+    return null;
   }
 
   async #get(url: string, headers: Record<string, string>) {

--- a/lib/user-login.ts
+++ b/lib/user-login.ts
@@ -82,13 +82,13 @@ class UserLogin {
     return Buffer.from(response).toString('utf-8').replace(/\s+/g, '');
   }
 
-  #checkErrors(data: string): string | null {
+  #checkErrors(data: string): string {
     for (const [key, message] of Object.entries(ERROR_MESSAGES)) {
       if (data.includes(key)) {
         return message;
       }
     }
-    return null;
+    return '未知错误';
   }
 
   async #get(url: string, headers: Record<string, string>) {
@@ -129,6 +129,12 @@ class UserLogin {
     };
 
     const { data: _data } = await this.#post(JWCH_URLS.LOGIN_CHECK, headers, formData);
+    if (!_data) {
+      return rejectWith({
+        type: RejectEnum.NativeLoginFailed,
+        data: '接收到数据为空',
+      });
+    }
     const data = this.#responseToString(_data);
     const result = this.#checkErrors(data);
     if (result) {
@@ -239,6 +245,14 @@ class UserLogin {
     };
 
     const { data: _data, headers: resHeaders } = await this.#post(YJSY_URLS.LOGIN, headers, formData);
+    // 需要判断_data是否为 null
+    if (!_data) {
+      return rejectWith({
+        type: RejectEnum.NativeLoginFailed,
+        data: '接收到数据为空',
+      });
+    }
+
     const data = this.#responseToString(_data);
     const result = this.#checkErrors(data);
     if (result) {


### PR DESCRIPTION
经过排查，基本确定了导致`The first argument must be one of type string, Buffer, ArrayBuffer, Array or Array-like Object. Received type object`的问题定位：

问题出现在`RejectEnum.NativeLoginFailed`这个情况下，而且只出现在这个情况下。进行排查后，有注意到目前绝大多数 throw 这个的 case 都是有 string 注明错误情况，只有少部分直接返回了类似 `result`这样的变量。

全局检索，抛出 error 没有做处理直接 throw 的 case 基本是这样的：
```typescript
      return rejectWith({
        type: RejectEnum.NativeLoginFailed,
        data: result,
      });
```

摸索后，基本可以确定，我们在以下情况没有进行处理

1. response 为空，即 null，这个是可能出现的

这个 pr 进行了修正：对于请求后，我们都会检查数据是否是 null，如果数据是 null，我们直接返回数据为空。

还有一个 null 情况是 checkError 时会出现的，后续注意到都有处理，因此 revert 掉，基本可以确定就是第一个原因导致的这个问题。