### PR TITLE
iOS26下问题修复

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "expo-blur": "^14.0.3",
     "expo-build-properties": "~0.13.2",
     "expo-calendar": "~14.0.6",
-    "expo-camera": "~16.0.17",
+    "expo-camera": "^16.1.8",
     "expo-constants": "~17.0.5",
     "expo-crypto": "~14.0.2",
     "expo-image": "~2.0.4",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "expo-intent-launcher": "~12.0.2",
     "expo-linear-gradient": "^14.0.2",
     "expo-linking": "~7.0.5",
-    "expo-localization": "~16.0.1",
+    "expo-localization": "^16.1.5",
     "expo-navigation-bar": "^4.0.7",
     "expo-quick-actions": "^4.0.2",
     "expo-router": "~4.0.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5531,10 +5531,10 @@ expo-linking@~7.0.5:
     expo-constants "~17.0.5"
     invariant "^2.2.4"
 
-expo-localization@~16.0.1:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/expo-localization/-/expo-localization-16.0.1.tgz#a6016288f0e4a5acef143d2a39ac3e5b4ac8963e"
-  integrity sha512-kUrXiV/Pq9r7cG+TMt+Qa49IUQ9Y/czVwen4hmiboTclTopcWdIeCzYZv6JGtufoPpjEO9vVx1QJrXYl9V2u0Q==
+expo-localization@^16.1.5:
+  version "16.1.5"
+  resolved "https://registry.yarnpkg.com/expo-localization/-/expo-localization-16.1.5.tgz#b2877f514669924b2a99d7f85d90e2378bee9e10"
+  integrity sha512-dymvf0S11afyMeRbnoXd2iWWzFYwg21jHTnLBO/7ObNO1rKlYpus0ghVDnh+sJFV2u7s518e/JTcAqNR69EZkw==
   dependencies:
     rtl-detect "^1.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5467,10 +5467,10 @@ expo-calendar@~14.0.6:
   resolved "https://registry.yarnpkg.com/expo-calendar/-/expo-calendar-14.0.6.tgz#b72194e231f0ccdd0425f39ee08b93b1efcefbe7"
   integrity sha512-aOby7ueR8lB9sWTHXkECZiPDZNVRsGQYhJTe05puNZicMWCV4c53Z/LRiCTTq3LBXV4zpBOB5rXiCyA1f082yA==
 
-expo-camera@~16.0.17:
-  version "16.0.17"
-  resolved "https://registry.npmmirror.com/expo-camera/-/expo-camera-16.0.17.tgz#c8dc56ff15a31c8faa7957dfffc34645f19867d1"
-  integrity sha512-V7yBcjQSx65ySKEN8NpCPaFQRL6haGW/hNFvlRuD3+e98sxwQQtcni/EkfTUmZDw81OuURO1c6vTr2oI33WM4Q==
+expo-camera@^16.1.8:
+  version "16.1.8"
+  resolved "https://registry.yarnpkg.com/expo-camera/-/expo-camera-16.1.8.tgz#6c30dfb5c982795351f1053c36f048a11869e21b"
+  integrity sha512-NpBbkUhHG6cs2TNUQBFSEtXb5j1/kTPIhiuqBcHosZG2yb/8MuM/ii4McJaqfe/6pn0YPqkH4k0Uod11DOSLmw==
   dependencies:
     invariant "^2.2.4"
 


### PR DESCRIPTION
更新expo-localization和expo-camera，解决macOS26编译报错，iOS26下无法扫码问题待测试