### PR TITLE
fix: Toast on android 背景阴影效果不佳，更新sonner-native

### DIFF
--- a/app/(guest)/academic-login.tsx
+++ b/app/(guest)/academic-login.tsx
@@ -76,6 +76,7 @@ const LoginPage: React.FC = () => {
     try {
       const res = await loginRef.current!.getCaptcha();
       setCaptchaImage(`data:image/png;base64,${btoa(String.fromCharCode(...res))}`);
+      setCaptcha(''); // 清空验证码输入框
     } catch (error) {
       console.error(error);
       toast.error('获取验证码失败');

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import { PortalHost } from '@rn-primitives/portal';
 import { Stack } from 'expo-router';
 import { useColorScheme } from 'nativewind';
 import { useEffect } from 'react';
+import { Platform } from 'react-native';
 import { SystemBars } from 'react-native-edge-to-edge';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
@@ -57,7 +58,7 @@ export default function RootLayout() {
                   <Stack.Screen name="+not-found" />
                 </Stack>
 
-                <Toaster cn={cn} position="top-center" duration={2500} offset={100} />
+                <Toaster position="top-center" duration={2500} offset={100} style={toastStyle} />
                 <PortalHost />
                 <SystemBars style="auto" />
                 <DownloadProgress />
@@ -69,3 +70,9 @@ export default function RootLayout() {
     </SafeAreaProvider>
   );
 }
+
+const toastStyle = {
+  // For better toast background on android
+  // Overrides https://github.com/gunnartorfis/sonner-native/blob/9656057710310528e05d98ae22d21520004cf8fa/src/toast.tsx#L504
+  ...(Platform.OS === 'android' && { elevation: 20 }),
+};

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,7 +16,6 @@ import { QueryProvider } from '@/components/query-provider';
 import { LearningCenterContextProvider } from '@/context/learning-center';
 import { getColorScheme } from '@/lib/appearance';
 import { StackNavigatorScreenOptions } from '@/lib/constants';
-import { cn } from '@/lib/utils';
 import patchTextComponent from '@/utils/patch-text-component';
 import patchTextRender from '@/utils/patch-text-render';
 

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "react-native-ui-datepicker": "^3.1.2",
     "react-native-web": "~0.19.10",
     "react-native-webview": "~13.13.1",
-    "sonner-native": "^0.16.2",
+    "sonner-native": "^0.21.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss": "^3.4.14",
     "tailwindcss-animate": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10162,10 +10162,10 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-sonner-native@^0.16.2:
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/sonner-native/-/sonner-native-0.16.2.tgz#046fd9c750c08f51546bb2b9b53fc940f8c7bc7d"
-  integrity sha512-IxiqcwZ2ZqmbtMWWhFq/um31hQndEUOa9ERnhS7+Z7lc0v9b9boa9pjHtNRoDktJ/OzEOMb1ERyr2bCNYNdUog==
+sonner-native@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.npmmirror.com/sonner-native/-/sonner-native-0.21.0.tgz#b7968f8a7fdcdbc3b13b478455d63b24a45db829"
+  integrity sha512-pIdyMd722xuDukIvCZCmWh9Jy5FV+m9uKYl3oAzonYE+91eX5556vYrIik5MisDlBniSXaWqC9CnPoS6DKo2Lg==
 
 source-map-js@^1.0.1, source-map-js@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
toast四角的阴影效果不对，这个具体原因没查到，新建一个expo项目使用sonner-native是正常的

这边采用修改elevation的方式使效果看起来正常，阴影稍微变大一些（仅生效于Android）

另外，删除了cn参数，因sonner-native已移除nativewind支持