### PR TITLE
课表增加下拉刷新，修复周数越界导致的崩溃

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -43,13 +43,16 @@ export default function HomePage() {
   const loadConfigAndDateResult = useCallback(async () => {
     // const startTime = Date.now(); // 记录开始时间
 
-    const res = await locateDate();
+    const locateDateRes = await locateDate();
 
     // 获取最新的课表设置
     const setting = await AsyncStorage.getItem(COURSE_SETTINGS_KEY);
     const tryParsedSettings = setting ? JSON.parse(setting) : {};
-    const selectedSemester = tryParsedSettings.selectedSemester || res.semester;
+    const selectedSemester = tryParsedSettings.selectedSemester || locateDateRes.semester;
     const parsedSettings = normalizeCourseSetting({ ...tryParsedSettings, selectedSemester });
+
+    // 定位当前周，如果是历史学期（即和 locateDate 给出的学期不符），则为-1
+    const currentWeek = locateDateRes.semester === parsedSettings.selectedSemester ? locateDateRes.week : -1;
 
     // 获取当前学期信息
     const currentTerm = termsData?.data.data.terms.find(t => t.term === selectedSemester);
@@ -65,8 +68,7 @@ export default function HomePage() {
 
     setCoursePageContextProps({
       setting: parsedSettings,
-      // 如果是历史学期（即和 locateDate 给出的学期不符），则为-1，反之则是当前周
-      currentWeek: res.semester === parsedSettings.selectedSemester ? res.week : -1,
+      currentWeek,
       currentTerm,
       maxWeek,
     });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,22 +1,34 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFocusEffect } from 'expo-router';
-import { useCallback, useEffect, useState } from 'react';
+import { createContext, useCallback, useEffect, useState } from 'react';
 
 import CoursePage from '@/components/course/course-page';
 import Loading from '@/components/loading';
 
+import { TermsListResponse_Term } from '@/api/backend';
 import { getApiV1TermsList } from '@/api/generate';
 import type { CourseSetting } from '@/api/interface';
 import PageContainer from '@/components/page-container';
 import usePersistedQuery from '@/hooks/usePersistedQuery';
 import { COURSE_SETTINGS_KEY, COURSE_TERMS_LIST_KEY, EXPIRE_ONE_DAY } from '@/lib/constants';
 import { CourseCache, normalizeCourseSetting } from '@/lib/course';
-import locateDate from '@/lib/locate-date';
+import locateDate, { getWeeksBySemester } from '@/lib/locate-date';
 import { NotificationManager } from '@/lib/notification';
+import { toast } from 'sonner-native';
+
+interface CoursePageContextProps {
+  setting: CourseSetting; // 课程表设置
+  currentWeek: number; // 今天在选中学期的周数，如果今天不在选中学期内则为-1
+  currentTerm: TermsListResponse_Term; // 当前选中学期基本信息
+  maxWeek: number; // 当前选中学期的最大周数
+}
+
+// 此处这样写仅为了通过类型检查，实际使用时不可能为空
+export const CoursePageContext = createContext<CoursePageContextProps>({} as CoursePageContextProps);
 
 export default function HomePage() {
-  const [config, setConfig] = useState<CourseSetting | null>(null); // 课程设置
-  const [currentWeek, setCurrentWeek] = useState<number | null>(null); // 当前周数，默认第一周
+  const [coursePageContextProps, setCoursePageContextProps] = useState<CoursePageContextProps | null>(null);
+
   const [cacheInitialized, setCacheInitialized] = useState(false); // 缓存是否初始化
 
   // 这个学期数据（不是课程数据，是学期的开始结束时间等信息）存本地就可以了，本地做个长时间的缓存，这玩意一学期变一次，保守一点缓 7 天把
@@ -38,21 +50,35 @@ export default function HomePage() {
     const tryParsedSettings = setting ? JSON.parse(setting) : {};
     const selectedSemester = tryParsedSettings.selectedSemester || res.semester;
     const parsedSettings = normalizeCourseSetting({ ...tryParsedSettings, selectedSemester });
-    setConfig(parsedSettings);
+
+    // 获取当前学期信息
+    const currentTerm = termsData?.data.data.terms.find(t => t.term === selectedSemester);
+
+    if (!termsData || !currentTerm) {
+      console.error('Failed to load term data: ', termsData, currentTerm);
+      toast.error('获取学期信息失败，请稍后再试');
+      return;
+    }
+
+    // 获取当前学期的最大周数
+    const maxWeek = getWeeksBySemester(currentTerm.start_date, currentTerm.end_date);
+
+    setCoursePageContextProps({
+      setting: parsedSettings,
+      // 如果是历史学期（即和 locateDate 给出的学期不符），则为-1，反之则是当前周
+      currentWeek: res.semester === parsedSettings.selectedSemester ? res.week : -1,
+      currentTerm,
+      maxWeek,
+    });
 
     // 更新 AsyncStorage，仅在数据变化时写入
     if (JSON.stringify(tryParsedSettings) !== JSON.stringify(parsedSettings)) {
       await AsyncStorage.setItem(COURSE_SETTINGS_KEY, JSON.stringify(parsedSettings));
     }
-
-    // 如果是历史学期（即和 locateDate 给出的学期不符），则默认是第一周，反之则是当前周
-    setCurrentWeek(res.semester === parsedSettings.selectedSemester ? res.week : 1);
-
-    console.log('set initial week: ', res.semester === parsedSettings.selectedSemester ? res.week : 1);
     // const endTime = Date.now(); // 记录结束时间
     // const elapsedTime = endTime - startTime; // 计算耗时
     // console.log(`loadData function took ${elapsedTime}ms to complete.`);
-  }, []);
+  }, [termsData]);
 
   // 当加载的时候会读取 COURSE_SETTINGS，里面有一个字段会存储当前选择的学期（不一定是最新学期）
   useFocusEffect(
@@ -87,14 +113,11 @@ export default function HomePage() {
   // config 是课表的配置，locateDateResult 是当前时间的定位，termsData 是学期列表的数据（不包含课程数据）
   // 在 AsyncStorage 中，我们按照 COURSE_SETTINGS_KEY__{学期 ID} 的格式存储课表设置
   // 具体加载课程的逻辑在 CoursePage 组件中
-  return config && currentWeek && termsData ? (
+  return coursePageContextProps ? (
     <PageContainer refreshBackground>
-      <CoursePage
-        config={config}
-        initialWeek={currentWeek}
-        semesterList={termsData.data.data.terms}
-        currentTerm={termsData.data.data.current_term}
-      />
+      <CoursePageContext value={coursePageContextProps}>
+        <CoursePage />
+      </CoursePageContext>
     </PageContainer>
   ) : (
     <Loading />

--- a/components/course/course-page.tsx
+++ b/components/course/course-page.tsx
@@ -45,11 +45,14 @@ const CoursePage: React.FC = () => {
 
   // 周数切换，注意改变选中周必须使用该函数，以避免 FlatList 滚动越界导致崩溃
   const safeSetSelectedWeek = useCallback(
-    (week: number) => {
-      if (week < 1) {
-        setSelectedWeek(1);
-      } else {
-        setSelectedWeek(Math.min(week, maxWeek));
+    (week: number, scrollTo: boolean = true) => {
+      const targetWeek = Math.max(1, Math.min(week, maxWeek));
+      setSelectedWeek(targetWeek);
+      if (scrollTo && flatListRef.current) {
+        flatListRef.current.scrollToIndex({
+          index: targetWeek - 1,
+          animated: false,
+        });
       }
     },
     [maxWeek],
@@ -157,20 +160,12 @@ const CoursePage: React.FC = () => {
       if (viewableItems.length > 0) {
         const firstViewableWeek = viewableItems[0].item.week;
         if (firstViewableWeek !== selectedWeek) {
-          safeSetSelectedWeek(firstViewableWeek);
+          safeSetSelectedWeek(firstViewableWeek, false);
         }
       }
     },
     [safeSetSelectedWeek, selectedWeek],
   );
-
-  // selectedWeek 变化时，FlatList 滚动到对应周
-  useEffect(() => {
-    flatListRef?.current?.scrollToIndex({
-      index: selectedWeek - 1,
-      animated: false,
-    });
-  }, [currentWeek, maxWeek, selectedWeek]);
 
   // 生成周数选择器的数据
   const weekPickerData = useMemo(

--- a/components/course/course-page.tsx
+++ b/components/course/course-page.tsx
@@ -43,9 +43,9 @@ const CoursePage: React.FC = () => {
 
   const flatListRef = useRef<FlatList>(null);
 
+  // 周数切换，注意改变选中周必须使用该函数，以避免 FlatList 滚动越界导致崩溃
   const safeSetSelectedWeek = useCallback(
     (week: number) => {
-      console.log('Setting selected week:', week);
       if (week < 1) {
         setSelectedWeek(1);
       } else {

--- a/components/course/course-page.tsx
+++ b/components/course/course-page.tsx
@@ -285,7 +285,7 @@ const CoursePage: React.FC = () => {
         horizontal // 水平滚动
         pagingEnabled // 分页滚动
         data={weekArray} // 数据源
-        initialNumToRender={4} // 初始渲染数量
+        initialNumToRender={1} // 初始渲染数量，影响首屏速度
         windowSize={3} // 窗口大小
         getItemLayout={getItemLayout}
         initialScrollIndex={selectedWeek - 1} // 初始滚动位置

--- a/components/course/course-page.tsx
+++ b/components/course/course-page.tsx
@@ -1,5 +1,5 @@
 import { Tabs } from 'expo-router';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { FlatList, Pressable, View, useWindowDimensions, type LayoutRectangle, type ViewToken } from 'react-native';
 import { toast } from 'sonner-native';
 
@@ -8,29 +8,23 @@ import Loading from '@/components/loading';
 import PickerModal from '@/components/picker-modal';
 import { Text } from '@/components/ui/text';
 
-import type { TermsListResponse_Terms } from '@/api/backend';
 import { getApiV1JwchClassroomExam, getApiV1JwchCourseList } from '@/api/generate';
-import type { CourseSetting } from '@/api/interface';
 import { COURSE_DATA_KEY, EXAM_ROOM_KEY, EXPIRE_ONE_DAY } from '@/lib/constants';
 import { COURSE_TYPE, CourseCache, EXAM_TYPE, type CourseInfo } from '@/lib/course';
 import { formatExamData } from '@/lib/exam-room';
-import { deConvertSemester, getFirstDateByWeek, getWeeksBySemester } from '@/lib/locate-date';
+import { deConvertSemester, getFirstDateByWeek } from '@/lib/locate-date';
 import { LocalUser, USER_TYPE_POSTGRADUATE } from '@/lib/user';
 import { fetchWithCache } from '@/utils/fetch-with-cache';
 
+import { CoursePageContext } from '@/app/(tabs)';
 import { hasCustomBackground } from '@/lib/appearance';
 import CourseWeek from './course-week';
 
-interface CoursePageProps {
-  config: CourseSetting;
-  initialWeek: number;
-  semesterList: TermsListResponse_Terms;
-  currentTerm: string;
-}
-
 // 课程表页面
-const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterList, currentTerm }) => {
-  const [currentWeek, setCurrentWeek] = useState(initialWeek); // 当前周数
+const CoursePage: React.FC = () => {
+  const { setting, currentWeek, currentTerm, maxWeek } = useContext(CoursePageContext);
+
+  const [selectedWeek, setSelectedWeek] = useState(currentWeek === -1 ? 1 : Math.min(currentWeek, maxWeek)); // 选中周数，非当前学期则定位到第一周
   const [showWeekSelector, setShowWeekSelector] = useState(false);
   const { width } = useWindowDimensions(); // 获取屏幕宽度
   const [flatListLayout, setFlatListLayout] = useState<LayoutRectangle>({ width, height: 0, x: 0, y: 0 }); // FlatList 的布局信息
@@ -49,26 +43,17 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
 
   const flatListRef = useRef<FlatList>(null);
 
-  // 从设置中读取相关信息（比如当前选择的学期，是否显示非本周课程），设置项由上级组件传入
-  const {
-    selectedSemester: term,
-    showNonCurrentWeekCourses,
-    exportExamToCourseTable,
-    hiddenCoursesWithoutAttendances,
-  } = config;
-
-  // 以下是处理学期的数据
-  // 将学期数据转换为 Map，方便后续使用
-  const semesterListMap = useMemo(
-    () => Object.fromEntries(semesterList.map(semester => [semester.term, semester])),
-    [semesterList],
+  const safeSetSelectedWeek = useCallback(
+    (week: number) => {
+      console.log('Setting selected week:', week);
+      if (week < 1) {
+        setSelectedWeek(1);
+      } else {
+        setSelectedWeek(Math.min(week, maxWeek));
+      }
+    },
+    [maxWeek],
   );
-
-  // 获取当前学期的开始结束时间（即从 semesterList 中取出当前学期的信息，term 表示当前选择的学期）
-  // 需要注意的是，不论本科生还是研究生，term 的格式均遵循本科生数据格式，即 202401 这样的
-  // 对于研究生，locate-date 需要依赖本科教务系统（即使研究生院教务系统也是这样的），所以我们只选择在查询研究生课表的时候进行一个转化即可，不在这里做转化
-  // 相关转化逻辑请参考 @/lib/locate-date.ts 中相关函数
-  const currentSemester = useMemo(() => semesterListMap[term], [semesterListMap, term]);
 
   // 【查询课程数据】
   // 使用含缓存处理的查询 hooks，这样当网络请求失败时，会返回缓存数据
@@ -80,9 +65,9 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
         // 异步获取联网课程数据
         let hasChanged = false; // 是否有数据变更
         const hasCache = CourseCache.hasCachedData(); // 先判断是否有缓存
-        let queryTerm = term;
+        let queryTerm = currentTerm.term;
         if (LocalUser.getUser().type === USER_TYPE_POSTGRADUATE) {
-          queryTerm = deConvertSemester(term);
+          queryTerm = deConvertSemester(currentTerm.term);
         }
         const fetchedData = await fetchWithCache(
           [COURSE_DATA_KEY, queryTerm],
@@ -97,7 +82,7 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
         }
 
         // 若开启导入考场，则再拉取考场数据
-        if (exportExamToCourseTable) {
+        if (setting.exportExamToCourseTable) {
           const examData = await fetchWithCache(
             [EXAM_ROOM_KEY, queryTerm],
             () => getApiV1JwchClassroomExam({ term: queryTerm }),
@@ -106,7 +91,7 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
 
           const mergedExamData = formatExamData(examData.data.data);
           if (mergedExamData.length > 0 && !CourseCache.compareDigest(EXAM_TYPE, mergedExamData)) {
-            CourseCache.mergeExamCourses(mergedExamData, currentSemester.start_date, currentSemester.end_date);
+            CourseCache.mergeExamCourses(mergedExamData, currentTerm.start_date, currentTerm.end_date);
             hasChanged = true;
           } else if (mergedExamData.length === 0) {
             // 如果没有考试数据，但之前有缓存，则清除考试数据缓存
@@ -132,11 +117,18 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
         // 此时再进行滚动到指定周数，添加 NeedForceFetch 标记，强制刷新数据
         // 此时会让页面进入 Loading 状态
         setNeedForceFetch(true);
-        setCurrentWeek(initialWeek);
+        safeSetSelectedWeek(currentWeek);
       }
       return true;
     });
-  }, [term, exportExamToCourseTable, currentSemester, initialWeek]);
+  }, [
+    currentWeek,
+    safeSetSelectedWeek,
+    setting.exportExamToCourseTable,
+    currentTerm.term,
+    currentTerm.start_date,
+    currentTerm.end_date,
+  ]);
 
   // 订阅刷新事件，触发时更新课程数据状态
   useEffect(() => {
@@ -149,31 +141,36 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
     };
   }, []);
 
-  // 获取当前学期的最大周数
-  const maxWeek = useMemo(
-    () => getWeeksBySemester(currentSemester.start_date, currentSemester.end_date),
-    [currentSemester],
-  );
-
   // 生成一周的日期数据
   const weekArray = useMemo(
     () =>
       Array.from({ length: maxWeek }, (_, i) => ({
         week: i + 1,
-        firstDate: getFirstDateByWeek(currentSemester.start_date, i + 1),
+        firstDate: getFirstDateByWeek(currentTerm.start_date, i + 1),
       })),
-    [maxWeek, currentSemester],
+    [maxWeek, currentTerm],
   );
 
-  // 通过 view ability 回调获取当前周
+  // 通过 viewability 回调获取当前周
   const handleViewableItemsChanged = useCallback(
     ({ viewableItems }: { viewableItems: ViewToken<(typeof weekArray)[0]>[] }) => {
       if (viewableItems.length > 0) {
-        setCurrentWeek(viewableItems[0].item.week);
+        const firstViewableWeek = viewableItems[0].item.week;
+        if (firstViewableWeek !== selectedWeek) {
+          safeSetSelectedWeek(firstViewableWeek);
+        }
       }
     },
-    [],
+    [safeSetSelectedWeek, selectedWeek],
   );
+
+  // selectedWeek 变化时，FlatList 滚动到对应周
+  useEffect(() => {
+    flatListRef?.current?.scrollToIndex({
+      index: selectedWeek - 1,
+      animated: false,
+    });
+  }, [currentWeek, maxWeek, selectedWeek]);
 
   // 生成周数选择器的数据
   const weekPickerData = useMemo(
@@ -199,8 +196,10 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
           headerLeft: () => (
             <Pressable
               onPress={() => {
-                setCurrentWeek(initialWeek);
-                flatListRef.current?.scrollToIndex({ index: initialWeek - 1, animated: false });
+                if (selectedWeek !== -1) {
+                  // 如果是当前学期，点击快捷跳转到当前周
+                  safeSetSelectedWeek(currentWeek);
+                }
               }}
             >
               <Text className="ml-4 text-2xl font-medium">课程表</Text>
@@ -210,7 +209,7 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
           headerTitle: () => (
             <Pressable onPress={() => setShowWeekSelector(!showWeekSelector)} className="flex flex-row items-center">
               <Text className="mr-1 text-lg">
-                第 {currentWeek} 周 {currentWeek === initialWeek && currentTerm === term ? '(本周)' : ''}
+                第 {selectedWeek} 周 {selectedWeek === currentWeek ? '(本周)' : ''}
               </Text>
               <Icon name={showWeekSelector ? 'caret-up-outline' : 'caret-down-outline'} size={10} />
             </Pressable>
@@ -239,7 +238,7 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
           offset: flatListLayout.width * index, // 每个项的起始位置
           index, // 当前索引
         })}
-        initialScrollIndex={currentWeek - 1} // 初始滚动位置
+        initialScrollIndex={selectedWeek - 1} // 初始滚动位置
         // 渲染列表项（此处一项为一屏的内容）
         renderItem={({ item }) => (
           <CourseWeek
@@ -247,9 +246,6 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
             week={item.week}
             startDate={item.firstDate}
             schedulesByDays={schedulesByDays}
-            showNonCurrentWeekCourses={showNonCurrentWeekCourses}
-            hiddenCoursesWithoutAttendances={hiddenCoursesWithoutAttendances}
-            showExam={exportExamToCourseTable}
             flatListLayout={flatListLayout}
           />
         )}
@@ -266,20 +262,15 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
         visible={showWeekSelector}
         title="选择周数"
         data={weekPickerData}
-        value={String(currentWeek)}
+        value={String(selectedWeek)}
         onClose={() => setShowWeekSelector(false)}
         onConfirm={selectedValue => {
           setShowWeekSelector(false);
-          const selectedWeek = parseInt(selectedValue, 10);
-          setCurrentWeek(selectedWeek);
-          flatListRef.current?.scrollToIndex({
-            index: selectedWeek - 1,
-            animated: false,
-          });
+          safeSetSelectedWeek(parseInt(selectedValue, 10));
         }}
       />
     </>
   );
 };
 
-export default CoursePage;
+export default memo(CoursePage);

--- a/components/course/course-page.tsx
+++ b/components/course/course-page.tsx
@@ -27,7 +27,7 @@ const CoursePage: React.FC = () => {
   const [selectedWeek, setSelectedWeek] = useState(currentWeek === -1 ? 1 : Math.min(currentWeek, maxWeek)); // 选中周数，非当前学期则定位到第一周
   const [showWeekSelector, setShowWeekSelector] = useState(false);
   const { width } = useWindowDimensions(); // 获取屏幕宽度
-  const [flatListLayout, setFlatListLayout] = useState<LayoutRectangle>({ width, height: 0, x: 0, y: 0 }); // FlatList 的布局信息
+  const [flatListLayout, setFlatListLayout] = useState<LayoutRectangle | null>(null); // FlatList 的布局信息
   const [schedulesByDays, setSchedulesByDays] = useState<Record<number, CourseInfo[]>>([]); // 目前的课程数据，按天归类
   const [cacheInitialized, setCacheInitialized] = useState(false); // 缓存是否初始化
   const [needForceFetch, setNeedForceFetch] = useState(false); // 是否需要强制刷新
@@ -222,11 +222,11 @@ const CoursePage: React.FC = () => {
   // 提供固定的布局信息，有助于性能优化
   const getItemLayout = useCallback(
     (_: any, index: number) => ({
-      length: flatListLayout.width, // 每个项的宽度
-      offset: flatListLayout.width * index, // 每个项的起始位置
+      length: width, // 每个项的宽度
+      offset: width * index, // 每个项的起始位置
       index, // 当前索引
     }),
-    [flatListLayout.width],
+    [width],
   );
 
   // 渲染列表项（此处一项为一屏的内容）
@@ -276,6 +276,7 @@ const CoursePage: React.FC = () => {
 
       {/* 课程表详情 */}
       <FlatList
+        className="flex-1"
         ref={flatListRef} // 绑定 ref
         horizontal // 水平滚动
         pagingEnabled // 分页滚动

--- a/components/course/course-page.tsx
+++ b/components/course/course-page.tsx
@@ -132,10 +132,6 @@ const CoursePage: React.FC<CoursePageProps> = ({ config, initialWeek, semesterLi
         // 此时再进行滚动到指定周数，添加 NeedForceFetch 标记，强制刷新数据
         // 此时会让页面进入 Loading 状态
         setNeedForceFetch(true);
-        flatListRef.current?.scrollToIndex({
-          index: initialWeek - 1,
-          animated: false,
-        });
         setCurrentWeek(initialWeek);
       }
       return true;

--- a/components/course/course-week.tsx
+++ b/components/course/course-week.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useContext, useEffect, useMemo, useState } from 'react';
 import { ScrollView, View, type LayoutRectangle } from 'react-native';
 
 import DayItem from '@/components/course/day-item';
@@ -8,6 +8,7 @@ import { Text } from '@/components/ui/text';
 
 import { LEFT_TIME_COLUMN_WIDTH, TOP_CALENDAR_HEIGHT, type CourseInfo } from '@/lib/course';
 
+import { CoursePageContext } from '@/app/(tabs)';
 import CalendarCol from './calendar-col';
 import TimeCol from './time-col';
 
@@ -15,25 +16,16 @@ interface CourseWeekProps {
   week: number;
   startDate: string;
   schedulesByDays: Record<number, CourseInfo[]>;
-  showNonCurrentWeekCourses: boolean;
-  showExam: boolean;
-  hiddenCoursesWithoutAttendances: boolean;
   flatListLayout: LayoutRectangle;
 }
 
 const DAYS = ['一', '二', '三', '四', '五', '六', '日'];
 
-const CourseWeek: React.FC<CourseWeekProps> = ({
-  week,
-  startDate,
-  schedulesByDays,
-  showNonCurrentWeekCourses,
-  hiddenCoursesWithoutAttendances,
-  showExam,
-  flatListLayout,
-}) => {
+const CourseWeek: React.FC<CourseWeekProps> = ({ week, startDate, schedulesByDays, flatListLayout }) => {
   const month = useMemo(() => new Date(startDate).getMonth() + 1, [startDate]);
   const [currentDate, setCurrentDate] = useState(dayjs());
+
+  const { setting } = useContext(CoursePageContext);
 
   useEffect(() => {
     // TODO: 需要做一个优化，由于这个 course-week 组件是嵌套在 FlatList 中的，因此刷新时候会同时刷新多个 course-week 组件
@@ -96,10 +88,10 @@ const CourseWeek: React.FC<CourseWeekProps> = ({
               <CalendarCol
                 key={`${startDate}_${i}`}
                 week={week}
-                showExam={showExam}
+                showExam={setting.exportExamToCourseTable}
                 schedulesOnDay={schedulesByDays[i] || []}
-                isShowNonCurrentWeekCourses={showNonCurrentWeekCourses}
-                hiddenCoursesWithoutAttendances={hiddenCoursesWithoutAttendances}
+                isShowNonCurrentWeekCourses={setting.showNonCurrentWeekCourses}
+                hiddenCoursesWithoutAttendances={setting.hiddenCoursesWithoutAttendances}
                 flatListLayout={{
                   ...flatListLayout,
                   width: flatListLayout.width - LEFT_TIME_COLUMN_WIDTH,

--- a/components/course/course-week.tsx
+++ b/components/course/course-week.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { memo, useContext, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { ScrollView, View, type LayoutRectangle } from 'react-native';
 
 import DayItem from '@/components/course/day-item';
@@ -8,24 +8,22 @@ import { Text } from '@/components/ui/text';
 
 import { LEFT_TIME_COLUMN_WIDTH, TOP_CALENDAR_HEIGHT, type CourseInfo } from '@/lib/course';
 
-import { CoursePageContext } from '@/app/(tabs)';
 import CalendarCol from './calendar-col';
 import TimeCol from './time-col';
 
 interface CourseWeekProps {
-  week: number;
-  startDate: string;
-  schedulesByDays: Record<number, CourseInfo[]>;
+  week: number; // 当前周数
+  startDate: string; // 当前周的开始日期
+  schedulesByDays: Record<number, CourseInfo[]>; // 当天课程数据
   flatListLayout: LayoutRectangle;
 }
 
 const DAYS = ['一', '二', '三', '四', '五', '六', '日'];
 
+// 一周课表
 const CourseWeek: React.FC<CourseWeekProps> = ({ week, startDate, schedulesByDays, flatListLayout }) => {
   const month = useMemo(() => new Date(startDate).getMonth() + 1, [startDate]);
   const [currentDate, setCurrentDate] = useState(dayjs());
-
-  const { setting } = useContext(CoursePageContext);
 
   useEffect(() => {
     // TODO: 需要做一个优化，由于这个 course-week 组件是嵌套在 FlatList 中的，因此刷新时候会同时刷新多个 course-week 组件
@@ -88,10 +86,7 @@ const CourseWeek: React.FC<CourseWeekProps> = ({ week, startDate, schedulesByDay
               <CalendarCol
                 key={`${startDate}_${i}`}
                 week={week}
-                showExam={setting.exportExamToCourseTable}
                 schedulesOnDay={schedulesByDays[i] || []}
-                isShowNonCurrentWeekCourses={setting.showNonCurrentWeekCourses}
-                hiddenCoursesWithoutAttendances={setting.hiddenCoursesWithoutAttendances}
                 flatListLayout={{
                   ...flatListLayout,
                   width: flatListLayout.width - LEFT_TIME_COLUMN_WIDTH,

--- a/components/course/course-week.tsx
+++ b/components/course/course-week.tsx
@@ -8,6 +8,7 @@ import { Text } from '@/components/ui/text';
 
 import { LEFT_TIME_COLUMN_WIDTH, TOP_CALENDAR_HEIGHT, type CourseInfo } from '@/lib/course';
 
+import { DATE_FORMAT_FULL } from '@/lib/constants';
 import CalendarCol from './calendar-col';
 import TimeCol from './time-col';
 
@@ -23,13 +24,13 @@ const DAYS = ['一', '二', '三', '四', '五', '六', '日'];
 // 一周课表
 const CourseWeek: React.FC<CourseWeekProps> = ({ week, startDate, schedulesByDays, flatListLayout }) => {
   const month = useMemo(() => new Date(startDate).getMonth() + 1, [startDate]);
-  const [currentDate, setCurrentDate] = useState(dayjs());
+  const [currentDate, setCurrentDate] = useState(dayjs().format(DATE_FORMAT_FULL)); // 当前日期
 
   useEffect(() => {
     // TODO: 需要做一个优化，由于这个 course-week 组件是嵌套在 FlatList 中的，因此刷新时候会同时刷新多个 course-week 组件
     // 我们期望的应该是只刷新正在呈现的 course-week 组件，但是从性能角度出发，不会有很大影响
     const interval = setInterval(() => {
-      setCurrentDate(dayjs());
+      setCurrentDate(dayjs().format(DATE_FORMAT_FULL));
     }, 1000 * 60); // 每分钟更新一次
 
     return () => clearInterval(interval); // 组件卸载时清除定时器

--- a/components/course/course-week.tsx
+++ b/components/course/course-week.tsx
@@ -17,7 +17,7 @@ interface CourseWeekProps {
   week: number; // 当前周数
   startDate: string; // 当前周的开始日期
   schedulesByDays: Record<number, CourseInfo[]>; // 当天课程数据
-  flatListLayout: LayoutRectangle;
+  flatListLayout: LayoutRectangle | null;
 }
 
 const DAYS = ['一', '二', '三', '四', '五', '六', '日'];
@@ -54,6 +54,12 @@ const CourseWeek: React.FC<CourseWeekProps> = ({ week, startDate, schedulesByDay
     });
   }, [startDate, currentDate]);
 
+  if (!flatListLayout) {
+    // FlatList 布局还未确定，此时渲染会导致高度的跳变
+    // 触发次数 = initialNumToRender
+    return null;
+  }
+
   return (
     <View className="flex flex-col" style={{ width: flatListLayout.width }}>
       <HeaderContainer style={{ width: flatListLayout.width, height: TOP_CALENDAR_HEIGHT }}>
@@ -77,26 +83,29 @@ const CourseWeek: React.FC<CourseWeekProps> = ({ week, startDate, schedulesByDay
           ))}
         </View>
       </HeaderContainer>
-      <ScrollView className="flex-1" showsVerticalScrollIndicator={false} overScrollMode="never">
-        <View className="flex flex-row">
-          {/* （左侧）时间列 */}
-          <TimeCol height={flatListLayout.height - TOP_CALENDAR_HEIGHT} />
+      <ScrollView
+        className="flex-1"
+        contentContainerClassName="flex flex-row"
+        showsVerticalScrollIndicator={false}
+        overScrollMode="never"
+      >
+        {/* （左侧）时间列 */}
+        <TimeCol height={flatListLayout.height - TOP_CALENDAR_HEIGHT} />
 
-          {/* 课程内容 */}
-          <View className="flex flex-1 flex-row">
-            {Array.from({ length: 7 }, (_, i) => (
-              <CalendarCol
-                key={`${startDate}_${i}`}
-                week={week}
-                schedulesOnDay={schedulesByDays[i] || []}
-                flatListLayout={{
-                  ...flatListLayout,
-                  width: flatListLayout.width - LEFT_TIME_COLUMN_WIDTH,
-                  height: flatListLayout.height - TOP_CALENDAR_HEIGHT,
-                }}
-              />
-            ))}
-          </View>
+        {/* 课程内容 */}
+        <View className="flex flex-1 flex-row">
+          {Array.from({ length: 7 }, (_, i) => (
+            <CalendarCol
+              key={`${startDate}_${i}`}
+              week={week}
+              schedulesOnDay={schedulesByDays[i] || []}
+              flatListLayout={{
+                ...flatListLayout,
+                width: flatListLayout.width - LEFT_TIME_COLUMN_WIDTH,
+                height: flatListLayout.height - TOP_CALENDAR_HEIGHT,
+              }}
+            />
+          ))}
         </View>
       </ScrollView>
     </View>

--- a/components/course/course-week.tsx
+++ b/components/course/course-week.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 import { memo, useEffect, useMemo, useState } from 'react';
-import { ScrollView, View, type LayoutRectangle } from 'react-native';
+import { View, type LayoutRectangle } from 'react-native';
 
 import DayItem from '@/components/course/day-item';
 import HeaderContainer from '@/components/course/header-container';
@@ -9,6 +9,7 @@ import { Text } from '@/components/ui/text';
 import { LEFT_TIME_COLUMN_WIDTH, TOP_CALENDAR_HEIGHT, type CourseInfo } from '@/lib/course';
 
 import { DATE_FORMAT_FULL } from '@/lib/constants';
+import { ScrollView } from 'react-native-gesture-handler';
 import CalendarCol from './calendar-col';
 import TimeCol from './time-col';
 

--- a/components/course/schedule-detail-dialog.tsx
+++ b/components/course/schedule-detail-dialog.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Text } from '@/components/ui/text';
 
-import { CUSTOM_TYPE, CourseCache, type CourseInfo } from '@/lib/course';
+import { CUSTOM_TYPE, CourseCache, CustomCourse, type CourseInfo } from '@/lib/course';
 import { pushToWebViewJWCH } from '@/lib/webview';
 
 import ArrowRightIcon from '@/assets/images/misc/ic_arrow_right.png';
@@ -36,12 +36,12 @@ const ScheduleDetailsDialog: React.FC<ScheduleDetailsDialogProps> = ({ open, onO
 
   const handleSyllabusPress = useCallback(() => {
     closeDialog();
-    pushToWebViewJWCH(schedule.syllabus, '教学大纲');
+    pushToWebViewJWCH(schedule.syllabus!, '教学大纲');
   }, [schedule.syllabus, closeDialog]);
 
   const handleLessonplanPress = useCallback(() => {
     closeDialog();
-    pushToWebViewJWCH(schedule.lessonplan, '授课计划');
+    pushToWebViewJWCH(schedule.lessonplan!, '授课计划');
   }, [schedule.lessonplan, closeDialog]);
 
   const setPriority = useCallback(
@@ -139,7 +139,7 @@ const ScheduleDetailsDialog: React.FC<ScheduleDetailsDialogProps> = ({ open, onO
                         href={{
                           pathname: '/settings/custom-course',
                           params: {
-                            key: schedule.storageKey,
+                            key: (schedule as CustomCourse).storageKey,
                           },
                         }}
                         onPress={closeDialog}
@@ -160,7 +160,7 @@ const ScheduleDetailsDialog: React.FC<ScheduleDetailsDialogProps> = ({ open, onO
                               style: 'destructive',
                               onPress: () => {
                                 closeDialog();
-                                CourseCache.removeCustomCourse(schedule.storageKey);
+                                CourseCache.removeCustomCourse((schedule as CustomCourse).storageKey);
                               },
                             },
                           ]);

--- a/components/course/schedule-item.tsx
+++ b/components/course/schedule-item.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { Pressable, useColorScheme, View } from 'react-native';
 
 import { Text } from '@/components/ui/text';
@@ -20,6 +20,7 @@ interface ScheduleItemProps {
 const ScheduleItem: React.FC<ScheduleItemProps> = ({ schedules, itemHeight, span, color }) => {
   const [isDetailsDialogOpen, setDetailsDialogOpen] = useState(false);
   const colorScheme = useColorScheme();
+  const isDarkMode = useMemo(() => colorScheme === 'dark', [colorScheme]);
 
   return (
     <>
@@ -27,19 +28,19 @@ const ScheduleItem: React.FC<ScheduleItemProps> = ({ schedules, itemHeight, span
         <Pressable
           className="flex flex-1 flex-col items-center justify-center overflow-hidden rounded-lg p-[1px]"
           style={{
-            backgroundColor: getCourseColor(color, colorScheme === 'dark'),
+            backgroundColor: getCourseColor(color, isDarkMode),
           }}
           onPress={() => setDetailsDialogOpen(true)}
         >
           <Text
             className={`${span > 1 ? 'line-clamp-3' : 'line-clamp-2'} truncate text-wrap break-all text-center text-[11px]`}
-            style={{ color: getTextColor(color, colorScheme === 'dark') }}
+            style={{ color: getTextColor(color, isDarkMode) }}
           >
             {schedules[0].name}
           </Text>
           <Text
             className="mt-1 text-wrap break-all text-center text-[11px]"
-            style={{ color: getTextColor(color, colorScheme === 'dark') }}
+            style={{ color: getTextColor(color, isDarkMode) }}
           >
             {schedules[0].location}
           </Text>

--- a/components/course/schedule-item.tsx
+++ b/components/course/schedule-item.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { Pressable, useColorScheme, View } from 'react-native';
 
 import { Text } from '@/components/ui/text';
@@ -58,4 +58,4 @@ const ScheduleItem: React.FC<ScheduleItemProps> = ({ schedules, itemHeight, span
   );
 };
 
-export default ScheduleItem;
+export default memo(ScheduleItem);

--- a/components/course/schedule-item.tsx
+++ b/components/course/schedule-item.tsx
@@ -25,14 +25,14 @@ const ScheduleItem: React.FC<ScheduleItemProps> = ({ schedules, itemHeight, span
     <>
       <View style={{ padding: SCHEDULE_ITEM_MARGIN, height: span * itemHeight }}>
         <Pressable
-          className="flex flex-1 flex-col items-center justify-center rounded-lg p-[1px]"
+          className="flex flex-1 flex-col items-center justify-center overflow-hidden rounded-lg p-[1px]"
           style={{
             backgroundColor: getCourseColor(color, colorScheme === 'dark'),
           }}
           onPress={() => setDetailsDialogOpen(true)}
         >
           <Text
-            className="line-clamp-3 truncate text-wrap break-all text-center text-[11px]"
+            className={`${span > 1 ? 'line-clamp-3' : 'line-clamp-2'} truncate text-wrap break-all text-center text-[11px]`}
             style={{ color: getTextColor(color, colorScheme === 'dark') }}
           >
             {schedules[0].name}

--- a/hooks/usePersistedQuery.ts
+++ b/hooks/usePersistedQuery.ts
@@ -1,6 +1,5 @@
 import type { DefaultError, QueryClient, QueryKey } from '@tanstack/query-core';
-import { useQuery } from '@tanstack/react-query';
-import type { UseQueryOptions } from '@tanstack/react-query/src/types';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
 import { queryClient } from '@/components/query-provider';
 import { fetchWithCache } from '@/utils/fetch-with-cache';

--- a/lib/locate-date.ts
+++ b/lib/locate-date.ts
@@ -21,7 +21,7 @@ export async function fetchJwchLocateDate(): Promise<JWCHLocateDateResult> {
 
 // 基于教务处的数据定位今天是第几周，以及今天的日期
 // 返回一个对象，包含 date（当前日期）、week（当前周数）、day（当前星期几）、semester（当前学期，格式样例：202401）
-// e.g. { date: '2024-06-01', week: 23, day: 3, semester: '202401' }
+// e.g. { date: '2024/06/01', week: 23, day: 3, semester: '202401' }
 // 这个函数应当只会在课表业务中涉及
 // 使用了本地缓存，但是缓存逻辑和 PersistentQuery 不同，我们只在跨周时重新获取数据
 export default async function locateDate(noCache = false): Promise<LocateDateResult> {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "react-native-mime-types": "^2.5.0",
     "react-native-permissions": "^5.4.1",
     "react-native-qrcode-svg": "^6.3.12",
-    "react-native-reanimated": "~3.17.4",
+    "react-native-reanimated": "^3.19.0",
     "react-native-refresh-control": "^2.1.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@rn-primitives/switch": "^1.2.0",
     "@rn-primitives/tabs": "^1.2.0",
     "@rn-primitives/types": "^1.2.0",
-    "@tanstack/react-query": "^5.59.16",
+    "@tanstack/react-query": "^5.83.0",
     "@types/crypto-js": "^4.2.2",
     "@types/object-hash": "^3.0.6",
     "aegis-rn-sdk": "^1.39.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8620,10 +8620,10 @@ react-native-quick-base64@^2.0.5:
   resolved "https://registry.yarnpkg.com/react-native-quick-base64/-/react-native-quick-base64-2.2.0.tgz#fa417d1339a6df0bfa103b45b7e8a3dc73adc999"
   integrity sha512-r7/BRsRl8QKEhS0JsHW6QX9+8LrC6NNWlwNnBnZ69h2kbcfABYsUILT71obrs9fqElEIMzuYSI5aHID955akyQ==
 
-react-native-reanimated@~3.17.4:
-  version "3.17.5"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz#09ebe3c9e3379c5c0c588b7ab30c131ea29b60f0"
-  integrity sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==
+react-native-reanimated@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.19.0.tgz#3413dd8865eec549642a4a63cd4e5354a25043c7"
+  integrity sha512-FNfqLuPuVHsW9KcsZtnJqIPlMQvuySnSFJXgSt9fVDPqptbSUkiAF6MthUwd4Mxt05hCRcbV+T65CENgVS5iCg==
   dependencies:
     "@babel/plugin-transform-arrow-functions" "^7.0.0-0"
     "@babel/plugin-transform-class-properties" "^7.0.0-0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2428,17 +2428,17 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@tanstack/query-core@5.66.0":
-  version "5.66.0"
-  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.66.0.tgz#163f670b3b4e3b3cdbff6698ad44b2edfcaed185"
-  integrity sha512-J+JeBtthiKxrpzUu7rfIPDzhscXF2p5zE/hVdrqkACBP8Yu0M96mwJ5m/8cPPYQE9aRNvXztXHlNwIh4FEeMZw==
+"@tanstack/query-core@5.83.0":
+  version "5.83.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.83.0.tgz#ac3bf337007bb7ea97b1fd2e7c3ceb4240f36dbc"
+  integrity sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==
 
-"@tanstack/react-query@^5.59.16":
-  version "5.66.0"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.66.0.tgz#9f7aa1b3e844ea6a0ad2ee61fccaed76e614b865"
-  integrity sha512-z3sYixFQJe8hndFnXgWu7C79ctL+pI0KAelYyW+khaNJ1m22lWrhJU2QrsTcRKMuVPtoZvfBYrTStIdKo+x0Xw==
+"@tanstack/react-query@^5.83.0":
+  version "5.83.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.83.0.tgz#e72cacdb03d2e6a7e4f82f5b2fc228118941d499"
+  integrity sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==
   dependencies:
-    "@tanstack/query-core" "5.66.0"
+    "@tanstack/query-core" "5.83.0"
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
1. 修复假期期间计算的当前周大于最大周，导致scrollToIndex越界崩溃（左上角快速定位、设置中切换学期后返回触发）
2. 使用Context整理课程表逻辑
3. 左上角定位只对当前学期生效
4. 修复更新Expo53后课程详情弹窗背景消不掉
5. 增加课表页下拉刷新，待测试
6. 部分性能优化