### PR TITLE
支持配置规则禁用组件、函数等

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 // https://docs.expo.dev/guides/using-eslint/
-const { forbiddenList } = require('./forbidden-rule.js');
+const forbiddenRule = require('./forbidden-rule');
 
 module.exports = {
   root: true,
@@ -24,11 +24,19 @@ module.exports = {
     ],
     'no-restricted-imports': [
       'error',
-      ...forbiddenList.map(item => ({
+      ...forbiddenRule.map(item => ({
         name: item.source,
         importNames: item.names,
         message: item.message,
       })),
     ],
   },
+  overrides: forbiddenRule
+    .filter(item => item.allowIn?.length)
+    .map(item => ({
+      files: item.allowIn.map(path => `${path}**/*`),
+      rules: {
+        'no-restricted-imports': 'off',
+      },
+    })),
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,6 @@
 // https://docs.expo.dev/guides/using-eslint/
+const { forbiddenList } = require('./forbidden-rule.js');
+
 module.exports = {
   root: true,
   extends: ['@react-native', 'expo', 'prettier', 'plugin:react/jsx-runtime'],
@@ -19,6 +21,14 @@ module.exports = {
         exports: 'always-multiline',
         functions: 'only-multiline',
       },
+    ],
+    'no-restricted-imports': [
+      'error',
+      ...forbiddenList.map(item => ({
+        name: item.source,
+        importNames: item.names,
+        message: item.message,
+      })),
     ],
   },
 };

--- a/app/devtools/async-storage-list.tsx
+++ b/app/devtools/async-storage-list.tsx
@@ -3,6 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { Stack } from 'expo-router';
 import { useCallback, useEffect, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { Alert, Button, FlatList, Modal, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
 const MAX_LENGTH = 50; // 设置最大长度

--- a/babel-plugin-forbidden-imports.js
+++ b/babel-plugin-forbidden-imports.js
@@ -1,0 +1,47 @@
+const forbiddenRule = require('./forbidden-rule');
+
+module.exports = function ({ types: t }) {
+  return {
+    visitor: {
+      ImportDeclaration(pathNode, state) {
+        const filename = state.file.opts.filename || '';
+        const importSource = pathNode.node.source.value;
+
+        // 检查 ESLint 注释是否禁用本规则
+        const leadingComments = pathNode.node.leadingComments || [];
+        const hasESLintDisable = leadingComments.some(comment =>
+          /eslint-disable(-next-line)?\s+no-restricted-imports/.test(comment.value),
+        );
+        if (hasESLintDisable) return; // 放行
+
+        for (const rule of forbiddenRule) {
+          // 模块名不匹配，跳过
+          if (importSource !== rule.source) continue;
+
+          // 白名单路径匹配，跳过
+          if (rule.allowIn?.some(allowPath => filename.includes(allowPath))) {
+            return;
+          }
+
+          // 检查是否导入了禁止的名称
+          const banned = pathNode.node.specifiers.some(spec => {
+            if (t.isImportSpecifier(spec)) {
+              return rule.names.includes(spec.imported.name);
+            }
+            if (t.isImportDefaultSpecifier(spec)) {
+              return rule.names.includes('default');
+            }
+            if (t.isImportNamespaceSpecifier(spec)) {
+              return rule.names.includes('*');
+            }
+            return false;
+          });
+
+          if (banned) {
+            throw pathNode.buildCodeFrameError(rule.message);
+          }
+        }
+      },
+    },
+  };
+};

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,28 +1,7 @@
-const { forbiddenList } = require('./forbidden-rule.js');
-
 module.exports = function (api) {
   api.cache(true);
   return {
     presets: [['babel-preset-expo', { jsxImportSource: 'nativewind' }], 'nativewind/babel'],
-    plugins: [
-      function forbidImports() {
-        return {
-          visitor: {
-            ImportDeclaration(path) {
-              forbiddenList.forEach(rule => {
-                if (path.node.source.value === rule.source) {
-                  if (
-                    rule.names.length === 0 ||
-                    path.node.specifiers.some(spec => spec.imported && rule.names.includes(spec.imported.name))
-                  ) {
-                    throw path.buildCodeFrameError(rule.message);
-                  }
-                }
-              });
-            },
-          },
-        };
-      },
-    ],
+    plugins: ['./babel-plugin-forbidden-imports.js'],
   };
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,28 @@
+const { forbiddenList } = require('./forbidden-rule.js');
+
 module.exports = function (api) {
   api.cache(true);
   return {
     presets: [['babel-preset-expo', { jsxImportSource: 'nativewind' }], 'nativewind/babel'],
+    plugins: [
+      function forbidImports() {
+        return {
+          visitor: {
+            ImportDeclaration(path) {
+              forbiddenList.forEach(rule => {
+                if (path.node.source.value === rule.source) {
+                  if (
+                    rule.names.length === 0 ||
+                    path.node.specifiers.some(spec => spec.imported && rule.names.includes(spec.imported.name))
+                  ) {
+                    throw path.buildCodeFrameError(rule.message);
+                  }
+                }
+              });
+            },
+          },
+        };
+      },
+    ],
   };
 };

--- a/forbidden-rule.js
+++ b/forbidden-rule.js
@@ -7,10 +7,11 @@
  *   source: string; // 模块路径
  *   names: string[]; // 禁用的具体导出名（空数组表示整个模块）
  *   message: string; // 报错信息
+ *   allowIn?: string[]; // 白名单路径（可选，字符串数组，支持局部匹配）
  * }
  */
 
-export const forbiddenList = [
+module.exports = [
   {
     source: 'react-native',
     names: ['SafeAreaView'],
@@ -20,5 +21,10 @@ export const forbiddenList = [
     source: 'react-native',
     names: ['KeyboardAvoidingView'],
     message: '此组件不支持 Android，请从 react-native-keyboard-controller 导入',
+  },
+  {
+    source: 'react-native',
+    names: ['Text'],
+    message: '此组件不适配主题，请从 @/components/ui/text 导入',
   },
 ];

--- a/forbidden-rule.js
+++ b/forbidden-rule.js
@@ -1,6 +1,7 @@
 /**
  * 此文件规范开发中禁止使用的组件和函数等，避免误用产生的问题
  * 在 .eslintrc.js 和 babel.config.js 中引用
+ * 违反规则将导致 eslint 报错，且无法编译通过，如确需使用可添加 eslint-disable 注释或配置 allowIn 白名单路径
  *
  * 配置规则说明如下：
  * interface ForbiddenRule {
@@ -15,7 +16,7 @@ module.exports = [
   {
     source: 'react-native',
     names: ['SafeAreaView'],
-    message: '此组件仅支持 iOS 且不能配置 edges，请从 react-native-safe-area-context 导入',
+    message: '此组件仅支持 iOS 且不能配置 edges，请从 react-native-safe-area-context 导入，或使用 useSafeAreaInsets()',
   },
   {
     source: 'react-native',
@@ -24,7 +25,7 @@ module.exports = [
   },
   {
     source: 'react-native',
-    names: ['Text'],
-    message: '此组件不适配主题，请从 @/components/ui/text 导入',
+    names: ['Button'],
+    message: '此组件不适配主题，请从 @/components/ui/ 导入',
   },
 ];

--- a/forbidden-rule.js
+++ b/forbidden-rule.js
@@ -1,0 +1,24 @@
+/**
+ * 此文件规范开发中禁止使用的组件和函数等，避免误用产生的问题
+ * 在 .eslintrc.js 和 babel.config.js 中引用
+ *
+ * 配置规则说明如下：
+ * interface ForbiddenRule {
+ *   source: string; // 模块路径
+ *   names: string[]; // 禁用的具体导出名（空数组表示整个模块）
+ *   message: string; // 报错信息
+ * }
+ */
+
+export const forbiddenList = [
+  {
+    source: 'react-native',
+    names: ['SafeAreaView'],
+    message: '此组件仅支持 iOS 且不能配置 edges，请从 react-native-safe-area-context 导入',
+  },
+  {
+    source: 'react-native',
+    names: ['KeyboardAvoidingView'],
+    message: '此组件不支持 Android，请从 react-native-keyboard-controller 导入',
+  },
+];


### PR DESCRIPTION
为了规范后续开发，避免误用组件或函数产生问题，引入黑名单机制

违反规则将导致 eslint 报错，且无法编译通过，如确需使用可添加 eslint-disable 注释或配置 allowIn 白名单路径