### PR TITLE
依赖清理和更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "react-native-qrcode-svg": "^6.3.12",
     "react-native-reanimated": "^3.19.0",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "~4.11.1",
+    "react-native-screens": "^4.14.0",
     "react-native-svg": "^15.12.0",
     "react-native-ui-datepicker": "^3.1.2",
     "react-native-web": "^0.20.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "expo-status-bar": "~2.2.3",
     "expo-system-ui": "~5.0.10",
     "expo-tracking-transparency": "~5.2.4",
-    "expo-web-browser": "~14.2.0",
     "htmlparser2": "^10.0.0",
     "lucide-react-native": "^0.525.0",
     "nativewind": "^4.1.23",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "react-native-permissions": "^5.4.1",
     "react-native-qrcode-svg": "^6.3.12",
     "react-native-reanimated": "^3.19.0",
-    "react-native-refresh-control": "^2.1.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-svg": "^15.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8631,11 +8631,6 @@ react-native-reanimated@^3.19.0:
     invariant "^2.2.4"
     react-native-is-edge-to-edge "1.1.7"
 
-react-native-refresh-control@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-refresh-control/-/react-native-refresh-control-2.1.0.tgz#85cd378a59fee34b438928ee1b057e703ee60c1a"
-  integrity sha512-czYkIvw1/azE2OZC7W3dsxHsl2SE4QPNiqerKTPPY9ge5nsZIZQexmOtDisFQVJZMKsQg7LOAZ40lvAle0MCaQ==
-
 react-native-safe-area-context@5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz#04b51940408c114f75628a12a93569d30c525454"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5275,11 +5275,6 @@ expo-tracking-transparency@~5.2.4:
   resolved "https://registry.yarnpkg.com/expo-tracking-transparency/-/expo-tracking-transparency-5.2.4.tgz#f3e343e9094376e89ec590444ac05dda6b4ecd25"
   integrity sha512-Evog1rmbSLrODuG8AukEoV0y1RzQiJelX95rFuXY3kxHZQbiBOQ7YzAOsuYACztDf4XDoSODStdHSgUkgKNxJA==
 
-expo-web-browser@~14.2.0:
-  version "14.2.0"
-  resolved "https://registry.yarnpkg.com/expo-web-browser/-/expo-web-browser-14.2.0.tgz#d8fb521ae349aebbf5c0ca32448877480124c06c"
-  integrity sha512-6S51d8pVlDRDsgGAp8BPpwnxtyKiMWEFdezNz+5jVIyT+ctReW42uxnjRgtsdn5sXaqzhaX+Tzk/CWaKCyC0hw==
-
 expo@^53.0.0:
   version "53.0.19"
   resolved "https://registry.yarnpkg.com/expo/-/expo-53.0.19.tgz#69f8ed224efadf517d3ff66dde3d536fb3e8f00a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8570,7 +8570,7 @@ react-native-is-edge-to-edge@1.1.7:
   resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz#28947688f9fafd584e73a4f935ea9603bd9b1939"
   integrity sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==
 
-react-native-is-edge-to-edge@^1.1.6, react-native-is-edge-to-edge@^1.1.7:
+react-native-is-edge-to-edge@^1.1.6, react-native-is-edge-to-edge@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz#64e10851abd9d176cbf2b40562f751622bde3358"
   integrity sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==
@@ -8631,13 +8631,13 @@ react-native-safe-area-context@5.4.0:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz#04b51940408c114f75628a12a93569d30c525454"
   integrity sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==
 
-react-native-screens@~4.11.1:
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.11.1.tgz#7d0f3d313d8ddc1e55437c5e038f15f8805dc991"
-  integrity sha512-F0zOzRVa3ptZfLpD0J8ROdo+y1fEPw+VBFq1MTY/iyDu08al7qFUO5hLMd+EYMda5VXGaTFCa8q7bOppUszhJw==
+react-native-screens@^4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.14.0.tgz#585c84954f2c0a60b8726deb5940c2c0b20b0f1b"
+  integrity sha512-BMTQ30IozI8ZkqqPw71LbiaEcU+F5wDmfXDFlVn0wupZnxt0l7x7lUh2nljxR7rNHQneNIZoRTlu0ExK0R0xmA==
   dependencies:
     react-freeze "^1.0.0"
-    react-native-is-edge-to-edge "^1.1.7"
+    react-native-is-edge-to-edge "^1.2.1"
     warn-once "^0.1.0"
 
 react-native-svg-transformer@^1.5.1:


### PR DESCRIPTION
1. 删除`react-native-refresh-control` `expo-web-browser`：未使用
2. 更新`react-native-screens`至4.14.0：该版本修复了iOS26下的一些问题，包括快速点击左上角返回页面跳动等。https://github.com/software-mansion/react-native-screens/releases/tag/4.14