### PR TITLE
fix: 刷新token过期时不能弹出重新登录的问题

### DIFF
--- a/api/axios.ts
+++ b/api/axios.ts
@@ -92,7 +92,7 @@ request.interceptors.response.use(
           });
           if (res.data.code !== ResultEnum.SuccessCode) {
             // 这里颗粒度粗一点，直接表示鉴权失败，统一返回 Login 页
-            return rejectWith({ type: RejectEnum.AuthFailed });
+            throw new Error(JSON.stringify(res.data));
           }
           await refreshToken(res.headers);
           queue.forEach(({ config: queuedConfig, resolve }) => {
@@ -103,7 +103,7 @@ request.interceptors.response.use(
           return request(config);
         } catch (error: unknown) {
           console.log('refresh token error:', error); // 此处可以控制台打印一下问题
-          queue.forEach(({ reject }) => reject(error));
+          queue.forEach(({ reject }) => reject({ type: RejectEnum.AuthFailed }));
           refreshing = false;
           queue = [];
           return rejectWith({ type: RejectEnum.AuthFailed });

--- a/lib/locate-date.ts
+++ b/lib/locate-date.ts
@@ -19,11 +19,15 @@ export async function fetchJwchLocateDate(): Promise<JWCHLocateDateResult> {
   };
 }
 
-// 基于教务处的数据定位今天是第几周，以及今天的日期
-// 返回一个对象，包含 date（当前日期）、week（当前周数）、day（当前星期几）、semester（当前学期，格式样例：202401）
-// e.g. { date: '2024/06/01', week: 23, day: 3, semester: '202401' }
-// 这个函数应当只会在课表业务中涉及
-// 使用了本地缓存，但是缓存逻辑和 PersistentQuery 不同，我们只在跨周时重新获取数据
+/**
+ * 基于教务处的数据定位今天是第几周，以及今天的日期
+ * 返回一个对象，包含 date（当前日期）、week（当前周数）、day（当前星期几）、semester（当前学期，格式样例：202401）
+ * e.g. { date: '2024/06/01', week: 23, day: 3, semester: '202401' }
+ * 这个函数应当只会在课表业务中涉及
+ * 使用了本地缓存，但是缓存逻辑和 PersistentQuery 不同，我们只在跨周时重新获取数据
+ * 调用接口取数据，需要用 handleError 做 catch
+ * @param noCache 是否使用缓存，默认使用
+ */
 export default async function locateDate(noCache = false): Promise<LocateDateResult> {
   // 获取当前日期
   const currentDate = dayjs();


### PR DESCRIPTION
鉴权失败时确保队列内请求被正确处理；
课程表页面使用handleError确保进入相关流程

当前情况：启动首先进入课表，调用locatedate，鉴权失败，由于没有handleError，没有弹出重新登录；切换其他页面，因为鉴权失败时直接返回了，refreshing===true，其他的请求会一直被卡住，最终体现为整个app的假loading状态。