### PR TITLE
bump version 7.1.8, improve ci & apk size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,18 +34,16 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22
           cache: yarn
 
       - uses: actions/setup-java@v4
         with:
           distribution: microsoft
-          java-version: 17.0
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          gradle-version: 8.8
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build APK
 on:
   push:
     branches:
-      - chore/ci+apk
+      - master
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build APK
 on:
   push:
     branches:
-      - master
+      - chore/ci+apk
   workflow_dispatch:
 
 concurrency:

--- a/app.config.ts
+++ b/app.config.ts
@@ -87,6 +87,8 @@ const config: ExpoConfig = {
         android: {
           useLegacyPackaging: true,
           enableProguardInReleaseBuilds: true,
+          enableShrinkResourcesInReleaseBuilds: true,
+          enableDangerousExperimentalLeanBuilds: true,
           usesCleartextTraffic: true,
           extraMavenRepos: ['https://developer.huawei.com/repo/'],
         },

--- a/app.config.ts
+++ b/app.config.ts
@@ -88,7 +88,6 @@ const config: ExpoConfig = {
           useLegacyPackaging: true,
           enableProguardInReleaseBuilds: true,
           enableShrinkResourcesInReleaseBuilds: true,
-          enableDangerousExperimentalLeanBuilds: true,
           usesCleartextTraffic: true,
           extraMavenRepos: ['https://developer.huawei.com/repo/'],
         },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fzuhelper-app",
   "main": "expo-router/entry",
   "//": "下面的 version 每一位都只能是【一位】数字！！！",
-  "version": "7.1.7",
+  "version": "7.1.8",
   "private": true,
   "scripts": {
     "start": "expo start",

--- a/plugins/inject-android-config.ts
+++ b/plugins/inject-android-config.ts
@@ -66,6 +66,17 @@ function withAndroidBuildConfig(config: ExpoConfig): ExpoConfig {
         }
     }`,
     );
+    contents = insertAfter(
+      contents,
+      'android {',
+      `
+    buildTypes {
+        release {
+            minifyEnabled true
+            shrinkResources true
+        }
+    }`,
+    );
     // versionCode根据commit次数设置
     // 前三位对应版本名，后三位或更多对应commit次数
     contents = contents.replace(

--- a/plugins/inject-android-config.ts
+++ b/plugins/inject-android-config.ts
@@ -66,17 +66,6 @@ function withAndroidBuildConfig(config: ExpoConfig): ExpoConfig {
         }
     }`,
     );
-    contents = insertAfter(
-      contents,
-      'android {',
-      `
-    buildTypes {
-        release {
-            minifyEnabled true
-            shrinkResources true
-        }
-    }`,
-    );
     // versionCode根据commit次数设置
     // 前三位对应版本名，后三位或更多对应commit次数
     contents = contents.replace(


### PR DESCRIPTION
1. 使用runner已缓存的组件加快构建
2. 启用expo及gradle相关减少apk体积的属性
参考：https://stackoverflow.com/questions/49993006/how-to-reduce-the-size-of-an-expo-react-native-app-on-android