### PR TITLE
修正小组件更新动画带来的时延

### DIFF
--- a/modules/native-widget/android/src/main/java/com/helper/west2ol/fzuhelper/NextClassWidgetProvider.kt
+++ b/modules/native-widget/android/src/main/java/com/helper/west2ol/fzuhelper/NextClassWidgetProvider.kt
@@ -53,12 +53,14 @@ class NextClassWidgetProvider : AppWidgetProvider() {
     }
 }
 
+@OptIn(DelicateCoroutinesApi::class)
 internal fun updateNextClassWidget(
     context: Context,
     appWidgetManager: AppWidgetManager,
     appWidgetId: Int
 ) {
-    CoroutineScope(Dispatchers.IO).launch {
+    // 避免内存泄漏可能
+    GlobalScope.launch(Dispatchers.IO) {
         doConfigMigration(context, appWidgetId)
 
         val views = RemoteViews(context.packageName, R.layout.next_class_widget_provider)


### PR DESCRIPTION
原方案在应用内刷新时会更新小组件数据，并同时更新小组件，导致刷新产生时延，现方案放在协程中进行。
为避免其他意料外的情况，考虑增加显示更新秒数并舍弃更新动画，或是将按钮更新与定时更新分离，询问意见...