### PR TITLE
修复 iOS 端 NativeRequest 偶发性反序列化出错问题

### DIFF
--- a/lib/sso-login.ts
+++ b/lib/sso-login.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer';
+import { Buffer } from '@craftzdog/react-native-buffer';
 import CryptoJs from 'crypto-js';
 
 import { RejectEnum } from '@/api/enum';
@@ -133,8 +133,7 @@ class SSOLogin {
 
     // 首先请求sso界面获得密钥
     const ssoPage = await this.#get({ url: SSO_LOGIN_URL });
-    let html: string;
-    html = Buffer.from(ssoPage.data).toString('utf-8');
+    let html: string = Buffer.from(ssoPage.data).toString('utf-8');
 
     // 从页面中提取密钥 和 cookie的session
     const matchCroypto = html.match(/"login-croypto">(.*?)</);

--- a/modules/native-request/index.ts
+++ b/modules/native-request/index.ts
@@ -4,7 +4,7 @@ import NativeRequestModule from './src/NativeRequestModule';
 
 interface NativeRequestResponse {
   status: number;
-  data: Uint8Array;
+  data: Uint8Array<ArrayBuffer>;
   headers: Record<string, string>;
 }
 

--- a/modules/native-request/ios/NativeRequestModule.swift
+++ b/modules/native-request/ios/NativeRequestModule.swift
@@ -11,7 +11,7 @@ struct ResponseMapper: Record {
   // 响应状态码
   @Field var status: Int = -1 // 默认为 -1
   // 数据内容
-  @Field var data: Data? = nil // 默认为空，需要 SDK50+ 支持
+  @Field var data: Data = Data() // 默认内容为空，需要 SDK50+ 支持
   // 响应头
   @Field var headers: [AnyHashable: Any] = [:]
   // 错误信息
@@ -39,11 +39,11 @@ public class NativeRequestModule: Module {
       configuration.timeoutIntervalForResource = 10 // 设置资源超时为 10 秒
       let session = Alamofire.Session(configuration: configuration, redirectHandler: NoRedirectHandler())
 
-      var resp = ResponseMapper(status: -1, data: nil, headers: [:], error: nil)
+      var resp = ResponseMapper(status: -1, data: Data(), headers: [:], error: nil)
       do {
         let response = await session.request(url, headers: HTTPHeaders(headers.data)).serializingData().response
         resp.status = response.response?.statusCode ?? -1
-        resp.data = response.data
+        resp.data = response.data ?? Data()
         resp.headers = response.response?.allHeaderFields ?? [:] // Headers
         return resp
       } catch {
@@ -60,11 +60,11 @@ public class NativeRequestModule: Module {
       configuration.timeoutIntervalForRequest = 10 // 设置请求超时为 10 秒
       configuration.timeoutIntervalForResource = 10 // 设置资源超时为 10 秒
       let session = Alamofire.Session(configuration: configuration, redirectHandler: NoRedirectHandler())
-      var resp = ResponseMapper(status: -1, data: nil, headers: [:], error: nil)
+      var resp = ResponseMapper(status: -1, data: Data(), headers: [:], error: nil)
       do{
         let response = await session.request(url, method: .post, parameters: formData.data, encoder: URLEncodedFormParameterEncoder.default, headers: HTTPHeaders(headers.data)).serializingData().response
         resp.status = response.response?.statusCode ?? -1
-        resp.data = response.data
+        resp.data = response.data ?? Data()
         resp.headers = response.response?.allHeaderFields ?? [:]
         return resp
       } catch {
@@ -81,11 +81,11 @@ public class NativeRequestModule: Module {
       configuration.timeoutIntervalForRequest = 10 // 设置请求超时为 10 秒
       configuration.timeoutIntervalForResource = 10 // 设置资源超时为 10 秒
       let session = Alamofire.Session(configuration: configuration, redirectHandler: NoRedirectHandler())
-      var resp = ResponseMapper(status: -1, data: nil, headers: [:], error: nil)
+      var resp = ResponseMapper(status: -1, data: Data(), headers: [:], error: nil)
       do {
         let response = await session.request(url, method: .post, parameters: formData.data, encoder: JSONParameterEncoder.default, headers: HTTPHeaders(headers.data)).serializingData().response
         resp.status = response.response?.statusCode ?? -1
-        resp.data = response.data
+        resp.data = response.data ?? Data()
         resp.headers = response.response?.allHeaderFields ?? [:]
         return resp
       } catch {


### PR DESCRIPTION
在服务端响应为空且请求正常完成时，Alamofire 会使反序列化出的 response.data 为 nil，映射到 JS侧即为 null，Buffer.from 会将 null 视作 object 类型导致反序列化失败报错。