### PR TITLE
fix(ui): prevent course info from squeezing other elements in onekey-comment

### DIFF
--- a/app/toolbox/onekey-comment/form.tsx
+++ b/app/toolbox/onekey-comment/form.tsx
@@ -86,7 +86,7 @@ const CourseCard = forwardRef<CourseCardRef, CourseCardProps>(function CourseCar
   return (
     <View className="mx-4 mt-4 space-y-2 rounded-xl border border-border bg-card p-5">
       <View className="flex-row items-center justify-between">
-        <View className="gap-1">
+        <View className="flex-1 gap-1">
           <Text className="font-bold text-text-primary">{courseName}</Text>
           <Text className="break-all text-text-secondary">{teacherName}</Text>
         </View>


### PR DESCRIPTION
<img width="424" height="330" alt="image" src="https://github.com/user-attachments/assets/d2c1864a-136d-45e4-b812-6dfcd952cd02" />
