### PR TITLE
fix: 修复长文本导致布局溢出

### DIFF
--- a/components/academic/ExamRoomCard.tsx
+++ b/components/academic/ExamRoomCard.tsx
@@ -32,10 +32,10 @@ interface CourseCardProps {
 const ExamRoomCard: React.FC<CourseCardProps> = ({ item }) => (
   <Card className={cn('p-3', item.isFinished && 'opacity-50')}>
     {/* 考试课程 */}
-    <View className="m-1 flex flex-row items-center justify-start">
-      <View className="flex flex-shrink flex-grow flex-row items-center">
-        <Icon name={item.isFinished ? 'checkmark-circle' : 'alert-circle'} size={16} className="mr-2" />
-        <Text className="mr-1 flex-shrink font-bold" numberOfLines={1}>
+    <View className="m-1 flex flex-row items-center justify-between">
+      <View className="mr-2 flex min-w-0 flex-1 flex-row items-center">
+        <Icon name={item.isFinished ? 'checkmark-circle' : 'alert-circle'} size={16} className="mr-2 flex-shrink-0" />
+        <Text className="mr-1 min-w-0 flex-shrink font-bold" numberOfLines={1} ellipsizeMode="tail">
           {getCourseName(item.name)}
         </Text>
         {item.credit !== undefined && item.credit !== '0' && (
@@ -43,7 +43,7 @@ const ExamRoomCard: React.FC<CourseCardProps> = ({ item }) => (
         )}
       </View>
 
-      <Text className="flex-shrink-0 justify-self-end text-ellipsis" numberOfLines={1}>
+      <Text className="max-w-[40%] flex-shrink text-right" numberOfLines={1} ellipsizeMode="tail">
         {item.teacher}
       </Text>
     </View>

--- a/components/free-friends/slot-detail-modal.tsx
+++ b/components/free-friends/slot-detail-modal.tsx
@@ -46,15 +46,15 @@ const SlotDetailModal: React.FC<SlotDetailModalProps> = ({ slotInfo, participant
                     : 'border-green-500 bg-green-50 dark:bg-green-950/20'
               }`}
             >
-              <View>
+              <View className="mr-3 min-w-0 flex-1">
                 <Text className="font-medium">{participant.name}</Text>
                 {participant.college && (
-                  <Text className="text-xs text-text-secondary">
+                  <Text className="text-xs text-text-secondary" numberOfLines={1} ellipsizeMode="tail">
                     {participant.college} · {participant.major}
                   </Text>
                 )}
               </View>
-              <View>
+              <View className="flex-shrink-0">
                 <Text
                   className={`text-sm font-bold ${
                     participant.isError


### PR DESCRIPTION
| befor | after |
| ----- | --- |
| <img width="460" height="417" alt="image" src="https://github.com/user-attachments/assets/4066a3e2-9142-4bd1-aeb7-bdc56719eed6" /> | <img width="452" height="384" alt="image" src="https://github.com/user-attachments/assets/4fcd2b67-d25b-4cf7-a093-be016907dd45" /> | 
|<img width="449" height="372" alt="image" src="https://github.com/user-attachments/assets/c643df69-d553-4318-b1fb-52dafe492381" />| <img width="401" height="292" alt="image" src="https://github.com/user-attachments/assets/8fac0b8c-e89a-42b4-a528-a492867d8e24" />|