### PR TITLE
feat: 课程详情显示所有时间段周数

### DIFF
--- a/components/course/calendar-col.tsx
+++ b/components/course/calendar-col.tsx
@@ -9,6 +9,7 @@ import {
   COURSE_TYPE,
   COURSE_WITHOUT_ATTENDANCE,
   type CourseInfo,
+  type CourseInfoMerged,
   CUSTOM_TYPE,
   EXAM_TYPE,
   SCHEDULE_ITEM_MIN_HEIGHT,
@@ -16,7 +17,7 @@ import {
 import { nonCurrentWeekCourseColor } from '@/utils/random-color';
 
 interface CourseScheduleItemDataBase {
-  schedules: CourseInfo[];
+  schedules: CourseInfoMerged[];
   span: number;
   color: string; // 课程的颜色
 }
@@ -46,58 +47,42 @@ const CalendarCol: React.FC<CalendarColProps> = ({ week, schedulesOnDay, flatLis
     const mainCourses: CourseScheduleItemDataBase[] = [];
 
     // 合并所有课程
-    const mergeMap = new Map<
-      string,
-      CourseInfo & {
-        weekSegments: {
-          start: number;
-          end: number;
-          isAdjusted?: boolean;
-          single?: boolean;
-          double?: boolean;
-        }[];
-      }
-    >();
+    const mergeMap = new Map<string, CourseInfoMerged>();
 
     schedulesOnDay.forEach(course => {
       const cleanName = course.name.replace(/^\[调课\]\s*/, '');
       const key = `${course.weekday}-${cleanName}-${course.startClass}-${course.endClass}-${course.location}`;
 
-      if (!mergeMap.has(key)) {
+      const currentWeekSegment = {
+        startWeek: course.startWeek,
+        endWeek: course.endWeek,
+        isAdjusted: course.name.startsWith('[调课]'),
+        single: course.single,
+        double: course.double,
+      };
+      const lesson = mergeMap.get(key);
+      if (!lesson) {
         mergeMap.set(key, {
           ...course,
           name: cleanName,
-          weekSegments: [
-            {
-              start: course.startWeek,
-              end: course.endWeek,
-              isAdjusted: course.name.startsWith('[调课]'),
-              single: course.single,
-              double: course.double,
-            },
-          ],
+          weekSegments: [currentWeekSegment],
+          weekDisplay: '', // 先占位，后面根据 weekSegments 生成显示文本
         });
       } else {
-        mergeMap.get(key)!.weekSegments.push({
-          start: course.startWeek,
-          end: course.endWeek,
-          isAdjusted: course.name.startsWith('[调课]'),
-          single: course.single,
-          double: course.double,
-        });
+        lesson.weekSegments.push(currentWeekSegment);
       }
     });
 
     const mergedSchedules = Array.from(mergeMap.values()).map(course => {
-      const sorted = course.weekSegments.sort((a, b) => a.start - b.start);
+      const sorted = course.weekSegments.sort((a, b) => a.startWeek - b.startWeek);
       const merged = [sorted[0]];
 
       // 合并相邻的周段
       for (let i = 1; i < sorted.length; i++) {
         const last = merged[merged.length - 1];
         const curr = sorted[i];
-        if (curr.start <= last.end + 1) {
-          last.end = Math.max(last.end, curr.end);
+        if (curr.startWeek <= last.endWeek + 1) {
+          last.endWeek = Math.max(last.endWeek, curr.endWeek);
         } else {
           merged.push(curr);
         }
@@ -106,12 +91,12 @@ const CalendarCol: React.FC<CalendarColProps> = ({ week, schedulesOnDay, flatLis
       let hasSingle = false;
       let hasDouble = false;
       merged.forEach(seg => {
-        for (let w = seg.start; w <= seg.end; w++) {
+        for (let w = seg.startWeek; w <= seg.endWeek; w++) {
           if (w % 2 === 1 && seg.single !== false) hasSingle = true;
           if (w % 2 === 0 && seg.double !== false) hasDouble = true;
         }
       });
-      const totalSpan = merged.reduce((sum, seg) => sum + (seg.end - seg.start + 1), 0);
+      const totalSpan = merged.reduce((sum, seg) => sum + (seg.endWeek - seg.startWeek + 1), 0);
 
       // 如果总周数 <= 2，视为正常课程（不限制单双周）
       if (totalSpan <= 2) {
@@ -123,17 +108,17 @@ const CalendarCol: React.FC<CalendarColProps> = ({ week, schedulesOnDay, flatLis
       }
 
       // 生成周数显示文本
-      (course as any).weekDisplay =
+      course.weekDisplay =
         merged
           .map(w => {
-            const weekStr = w.start === w.end ? `${w.start}` : `${w.start}-${w.end}`;
+            const weekStr = w.startWeek === w.endWeek ? `${w.startWeek}` : `${w.startWeek}-${w.endWeek}`;
             return weekStr;
           })
           .join(', ') + '周';
 
       // 用合并后的范围覆盖，保证筛选能通过
-      course.startWeek = merged[0].start;
-      course.endWeek = merged[merged.length - 1].end;
+      course.startWeek = merged[0].startWeek;
+      course.endWeek = merged[merged.length - 1].endWeek;
 
       return course;
     });

--- a/components/course/calendar-col.tsx
+++ b/components/course/calendar-col.tsx
@@ -45,8 +45,101 @@ const CalendarCol: React.FC<CalendarColProps> = ({ week, schedulesOnDay, flatLis
     // 主要的课程
     const mainCourses: CourseScheduleItemDataBase[] = [];
 
+    // 合并所有课程
+    const mergeMap = new Map<
+      string,
+      CourseInfo & {
+        weekSegments: {
+          start: number;
+          end: number;
+          isAdjusted?: boolean;
+          single?: boolean;
+          double?: boolean;
+        }[];
+      }
+    >();
+
+    schedulesOnDay.forEach(course => {
+      const cleanName = course.name.replace(/^\[调课\]\s*/, '');
+      const key = `${course.weekday}-${cleanName}-${course.startClass}-${course.endClass}-${course.location}`;
+
+      if (!mergeMap.has(key)) {
+        mergeMap.set(key, {
+          ...course,
+          name: cleanName,
+          weekSegments: [
+            {
+              start: course.startWeek,
+              end: course.endWeek,
+              isAdjusted: course.name.startsWith('[调课]'),
+              single: course.single,
+              double: course.double,
+            },
+          ],
+        });
+      } else {
+        mergeMap.get(key)!.weekSegments.push({
+          start: course.startWeek,
+          end: course.endWeek,
+          isAdjusted: course.name.startsWith('[调课]'),
+          single: course.single,
+          double: course.double,
+        });
+      }
+    });
+
+    const mergedSchedules = Array.from(mergeMap.values()).map(course => {
+      const sorted = course.weekSegments.sort((a, b) => a.start - b.start);
+      const merged = [sorted[0]];
+
+      // 合并相邻的周段
+      for (let i = 1; i < sorted.length; i++) {
+        const last = merged[merged.length - 1];
+        const curr = sorted[i];
+        if (curr.start <= last.end + 1) {
+          last.end = Math.max(last.end, curr.end);
+        } else {
+          merged.push(curr);
+        }
+      }
+      // 根据合并后的周段重新计算单双周
+      let hasSingle = false;
+      let hasDouble = false;
+      merged.forEach(seg => {
+        for (let w = seg.start; w <= seg.end; w++) {
+          if (w % 2 === 1 && seg.single !== false) hasSingle = true;
+          if (w % 2 === 0 && seg.double !== false) hasDouble = true;
+        }
+      });
+      const totalSpan = merged.reduce((sum, seg) => sum + (seg.end - seg.start + 1), 0);
+
+      // 如果总周数 <= 2，视为正常课程（不限制单双周）
+      if (totalSpan <= 2) {
+        course.single = true;
+        course.double = true;
+      } else {
+        course.single = hasSingle;
+        course.double = hasDouble;
+      }
+
+      // 生成周数显示文本
+      (course as any).weekDisplay =
+        merged
+          .map(w => {
+            const weekStr = w.start === w.end ? `${w.start}` : `${w.start}-${w.end}`;
+            return weekStr;
+          })
+          .join(', ') + '周';
+
+      // 用合并后的范围覆盖，保证筛选能通过
+      course.startWeek = merged[0].start;
+      course.endWeek = merged[merged.length - 1].end;
+
+      return course;
+    });
+
     // 先按优先级排本周的课和考试，重叠的不管
-    const today = schedulesOnDay
+    const today = mergedSchedules
       .filter(
         s =>
           s.startWeek <= week && // 卡起始时间范围
@@ -105,7 +198,7 @@ const CalendarCol: React.FC<CalendarColProps> = ({ week, schedulesOnDay, flatLis
 
     // 再按优先级去排非本周课（不含考试等），重叠的也不管
     if (setting.showNonCurrentWeekCourses) {
-      const nonCurrentWeek = schedulesOnDay
+      const nonCurrentWeek = mergedSchedules
         .filter(
           s =>
             !(
@@ -182,6 +275,7 @@ const CalendarCol: React.FC<CalendarColProps> = ({ week, schedulesOnDay, flatLis
             span={item.span}
             color={item.color}
             schedules={item.schedules}
+            week={week}
           />
         ) : (
           <EmptyScheduleItem key={index} itemHeight={itemHeight} />

--- a/components/course/schedule-detail-dialog.tsx
+++ b/components/course/schedule-detail-dialog.tsx
@@ -119,29 +119,10 @@ const ScheduleDetailsDialog: React.FC<ScheduleDetailsDialogProps> = ({ open, onO
                     </DescriptionListTerm>
                     <DescriptionListDescription>
                       <Text>
-                        {(() => {
-                          const filtered = schedules.filter(s => s.weekday === schedule.weekday);
-                          const groups = groupSchedulesByKey(filtered);
-                          return groups.map((group, groupIdx) => {
-                            const weekTexts = group.map(s =>
-                              s.startWeek === s.endWeek ? `${s.startWeek}周` : `${s.startWeek}-${s.endWeek}周`
-                            ).join('、');
-
-                            const suffix = (() => {
-                              const s = group[0];
-                              if (!s.double && s.single) return ' [单]';
-                              if (s.double && !s.single) return ' [双]';
-                              return '';
-                            })();
-
-                            return (
-                              <Text key={groupIdx}>
-                                {weekTexts}{suffix}
-                                {groupIdx < groups.length - 1 && '；'}
-                              </Text>
-                            );
-                          });
-                        })()}
+                        {(schedule as any).weekDisplay || `${schedule.startWeek}-${schedule.endWeek} 周`}
+                        {/* 单双周显示，仅在只有单周/双周上课的时候才显示提示 */}
+                        {scheduleIsSingleOnly && ' [单]'}
+                        {scheduleIsDoubleOnly && ' [双]'}
                       </Text>
                     </DescriptionListDescription>
                   </DescriptionListRow>

--- a/components/course/schedule-detail-dialog.tsx
+++ b/components/course/schedule-detail-dialog.tsx
@@ -91,24 +91,26 @@ const ScheduleDetailsDialog: React.FC<ScheduleDetailsDialogProps> = ({ open, onO
                   </DescriptionListRow>
                   <DescriptionListRow className="items-start">
                     <DescriptionListTerm>
-                      <Text>节数</Text>
-                    </DescriptionListTerm>
-                    <DescriptionListDescription>
-                      <Text>
-                        {schedule.startClass}-{schedule.endClass} 节
-                      </Text>
-                    </DescriptionListDescription>
-                  </DescriptionListRow>
-                  <DescriptionListRow className="items-start">
-                    <DescriptionListTerm>
                       <Text>周数</Text>
                     </DescriptionListTerm>
                     <DescriptionListDescription>
                       <Text>
-                        {schedule.startWeek}-{schedule.endWeek} 周
-                        {/* 单双周显示，仅在只有单周/双周上课的时候才显示提示 */}
-                        {scheduleIsSingleOnly && ' [单]'}
-                        {scheduleIsDoubleOnly && ' [双]'}
+                        {schedules.map((s, idx) => {
+                          const weekText = s.startWeek === s.endWeek
+                            ? `${s.startWeek}周`
+                            : `${s.startWeek}-${s.endWeek}周`;
+                          const suffix = (() => {
+                            if (!s.double && s.single) return ' [单]';
+                            if (s.double && !s.single) return ' [双]';
+                            return '';
+                          })();
+                          return (
+                            <Text key={idx}>
+                              {weekText}{suffix}
+                              {idx < schedules.length - 1 && '、'}
+                            </Text>
+                          );
+                        })}
                       </Text>
                     </DescriptionListDescription>
                   </DescriptionListRow>

--- a/components/course/schedule-detail-dialog.tsx
+++ b/components/course/schedule-detail-dialog.tsx
@@ -11,30 +11,16 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Text } from '@/components/ui/text';
 
-import { CUSTOM_TYPE, CourseCache, CustomCourse, type CourseInfo } from '@/lib/course';
+import { CUSTOM_TYPE, CourseCache, type CourseInfoMerged, type CustomCourse } from '@/lib/course';
 import { pushToWebViewJWCH } from '@/lib/webview';
 
 import ArrowRightIcon from '@/assets/images/misc/ic_arrow_right.png';
 import { Link } from 'expo-router';
 
-function groupSchedulesByKey(schedules: CourseInfo[]): CourseInfo[][] {
-  const groups: Record<string, CourseInfo[]> = {};
-
-  for (const s of schedules) {
-    const key = `${s.weekday}|${s.startClass}|${s.endClass}|${s.location}`;
-    if (!groups[key]) {
-      groups[key] = [];
-    }
-    groups[key].push(s);
-  }
-
-  return Object.values(groups);
-}
-
 interface ScheduleDetailsDialogProps {
   open: boolean;
   onOpenChange?: (open: boolean) => void;
-  schedules: CourseInfo[];
+  schedules: CourseInfoMerged[];
 }
 
 const ScheduleDetailsDialog: React.FC<ScheduleDetailsDialogProps> = ({ open, onOpenChange, schedules }) => {
@@ -59,7 +45,7 @@ const ScheduleDetailsDialog: React.FC<ScheduleDetailsDialogProps> = ({ open, onO
   }, [schedule.lessonplan, closeDialog]);
 
   const setPriority = useCallback(
-    (course: CourseInfo) => {
+    (course: CourseInfoMerged) => {
       closeDialog();
       CourseCache.setPriority(course);
     },
@@ -119,7 +105,7 @@ const ScheduleDetailsDialog: React.FC<ScheduleDetailsDialogProps> = ({ open, onO
                     </DescriptionListTerm>
                     <DescriptionListDescription>
                       <Text>
-                        {(schedule as any).weekDisplay || `${schedule.startWeek}-${schedule.endWeek} 周`}
+                        {schedule.weekDisplay || `${schedule.startWeek}-${schedule.endWeek} 周`}
                         {/* 单双周显示，仅在只有单周/双周上课的时候才显示提示 */}
                         {scheduleIsSingleOnly && ' [单]'}
                         {scheduleIsDoubleOnly && ' [双]'}

--- a/components/course/schedule-detail-dialog.tsx
+++ b/components/course/schedule-detail-dialog.tsx
@@ -17,6 +17,20 @@ import { pushToWebViewJWCH } from '@/lib/webview';
 import ArrowRightIcon from '@/assets/images/misc/ic_arrow_right.png';
 import { Link } from 'expo-router';
 
+function groupSchedulesByKey(schedules: CourseInfo[]): CourseInfo[][] {
+  const groups: Record<string, CourseInfo[]> = {};
+
+  for (const s of schedules) {
+    const key = `${s.weekday}|${s.startClass}|${s.endClass}|${s.location}`;
+    if (!groups[key]) {
+      groups[key] = [];
+    }
+    groups[key].push(s);
+  }
+
+  return Object.values(groups);
+}
+
 interface ScheduleDetailsDialogProps {
   open: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -91,26 +105,43 @@ const ScheduleDetailsDialog: React.FC<ScheduleDetailsDialogProps> = ({ open, onO
                   </DescriptionListRow>
                   <DescriptionListRow className="items-start">
                     <DescriptionListTerm>
+                      <Text>节数</Text>
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <Text>
+                        {schedule.startClass}-{schedule.endClass} 节
+                      </Text>
+                    </DescriptionListDescription>
+                  </DescriptionListRow>
+                  <DescriptionListRow className="items-start">
+                    <DescriptionListTerm>
                       <Text>周数</Text>
                     </DescriptionListTerm>
                     <DescriptionListDescription>
                       <Text>
-                        {schedules.map((s, idx) => {
-                          const weekText = s.startWeek === s.endWeek
-                            ? `${s.startWeek}周`
-                            : `${s.startWeek}-${s.endWeek}周`;
-                          const suffix = (() => {
-                            if (!s.double && s.single) return ' [单]';
-                            if (s.double && !s.single) return ' [双]';
-                            return '';
-                          })();
-                          return (
-                            <Text key={idx}>
-                              {weekText}{suffix}
-                              {idx < schedules.length - 1 && '、'}
-                            </Text>
-                          );
-                        })}
+                        {(() => {
+                          const filtered = schedules.filter(s => s.weekday === schedule.weekday);
+                          const groups = groupSchedulesByKey(filtered);
+                          return groups.map((group, groupIdx) => {
+                            const weekTexts = group.map(s =>
+                              s.startWeek === s.endWeek ? `${s.startWeek}周` : `${s.startWeek}-${s.endWeek}周`
+                            ).join('、');
+
+                            const suffix = (() => {
+                              const s = group[0];
+                              if (!s.double && s.single) return ' [单]';
+                              if (s.double && !s.single) return ' [双]';
+                              return '';
+                            })();
+
+                            return (
+                              <Text key={groupIdx}>
+                                {weekTexts}{suffix}
+                                {groupIdx < groups.length - 1 && '；'}
+                              </Text>
+                            );
+                          });
+                        })()}
                       </Text>
                     </DescriptionListDescription>
                   </DescriptionListRow>

--- a/components/course/schedule-item.tsx
+++ b/components/course/schedule-item.tsx
@@ -15,10 +15,11 @@ interface ScheduleItemProps {
   itemHeight: number;
   span: number;
   color: string; // 课程的颜色
+  week: number;
 }
 
 // ScheduleItem 组件，用于显示课程表中的一节课
-const ScheduleItem: React.FC<ScheduleItemProps> = ({ schedules, itemHeight, span, color }) => {
+const ScheduleItem: React.FC<ScheduleItemProps> = ({ schedules, itemHeight, span, color, week }) => {
   const [isDetailsDialogOpen, setDetailsDialogOpen] = useState(false);
   const { isDarkTheme } = useTheme();
 
@@ -36,6 +37,9 @@ const ScheduleItem: React.FC<ScheduleItemProps> = ({ schedules, itemHeight, span
             className={`${span > 1 ? 'line-clamp-3' : 'line-clamp-2'} truncate text-wrap break-all text-center text-[11px]`}
             style={{ color: getTextColor(color, isDarkTheme) }}
           >
+            {(schedules[0] as any).weekSegments?.some((w: any) => w.isAdjusted && week >= w.start && week <= w.end)
+              ? '[调课]'
+              : ''}
             {schedules[0].name}
           </Text>
           <Text

--- a/components/course/schedule-item.tsx
+++ b/components/course/schedule-item.tsx
@@ -4,14 +4,14 @@ import { Pressable, View } from 'react-native';
 import { Text } from '@/components/ui/text';
 
 import OverlapIcon from '@/assets/images/course/overlap.svg';
-import { SCHEDULE_ITEM_MARGIN, type CourseInfo } from '@/lib/course';
+import { SCHEDULE_ITEM_MARGIN, type CourseInfoMerged } from '@/lib/course';
 import { getCourseColor, getTextColor } from '@/utils/random-color';
 
 import { useTheme } from '../app-theme-provider';
 import ScheduleDetailsDialog from './schedule-detail-dialog';
 
 interface ScheduleItemProps {
-  schedules: CourseInfo[];
+  schedules: CourseInfoMerged[];
   itemHeight: number;
   span: number;
   color: string; // 课程的颜色
@@ -37,7 +37,7 @@ const ScheduleItem: React.FC<ScheduleItemProps> = ({ schedules, itemHeight, span
             className={`${span > 1 ? 'line-clamp-3' : 'line-clamp-2'} truncate text-wrap break-all text-center text-[11px]`}
             style={{ color: getTextColor(color, isDarkTheme) }}
           >
-            {(schedules[0] as any).weekSegments?.some((w: any) => w.isAdjusted && week >= w.start && week <= w.end)
+            {schedules[0].weekSegments.some(w => w.isAdjusted && week >= w.startWeek && week <= w.endWeek)
               ? '[调课]'
               : ''}
             {schedules[0].name}

--- a/lib/course.ts
+++ b/lib/course.ts
@@ -50,18 +50,39 @@ interface ExtendCourseBase extends ParsedCourse {
   priority: number; // 优先级
 }
 
+export enum CourseType {
+  COURSE = 0,
+  EXAM = 1,
+  CUSTOM = 2,
+}
+
 export type ExtendCourse = ExtendCourseBase & {
-  type: 0 | 1 | 2; // 课程类型（0 = 普通课程，1 = 考试，2 = 自定义课程）
+  type: CourseType; // 课程类型（0 = 普通课程，1 = 考试，2 = 自定义课程）
 };
 
 export type CustomCourse = ExtendCourseBase & {
-  type: 2;
+  type: CourseType.CUSTOM;
   storageKey: string; // 预留给后端的存储 key
   lastUpdateTime: string; // 最后更新时间
   semester: string; // 学期
 };
 
+export type WeekSegment = {
+  startWeek: number;
+  endWeek: number;
+  isAdjusted: boolean; // 是否为调课课程
+  single: boolean; // 是否单周
+  double: boolean; // 是否双周
+};
+
 export type CourseInfo = ExtendCourse | CustomCourse;
+
+// 同一个课程可能被教务系统分成不同周段，甚至有调课的情况，在展示课程信息前需要先整合
+// 具体逻辑在 calendar-col.tsx 中
+export type CourseInfoMerged = CourseInfo & {
+  weekSegments: WeekSegment[]; // 课程在不同周数的上课情况
+  weekDisplay: string; // 用于显示的周数文本
+};
 
 interface CacheCourseData {
   courseData: Record<number, ExtendCourse[]>; // 课程数据
@@ -81,9 +102,9 @@ export const SCHEDULE_MIN_HEIGHT = SCHEDULE_ITEM_MIN_HEIGHT * 11;
 export const LEFT_TIME_COLUMN_WIDTH = 32;
 export const TOP_CALENDAR_HEIGHT = 68;
 
-export const COURSE_TYPE = 0;
-export const EXAM_TYPE = 1;
-export const CUSTOM_TYPE = 2;
+export const COURSE_TYPE = CourseType.COURSE;
+export const EXAM_TYPE = CourseType.EXAM;
+export const CUSTOM_TYPE = CourseType.CUSTOM;
 export const COURSE_WITHOUT_ATTENDANCE = '免听';
 
 const NO_LOADING_MSG = '未加载';

--- a/lib/locate-date.ts
+++ b/lib/locate-date.ts
@@ -40,14 +40,21 @@ export default async function locateDate(noCache = false): Promise<LocateDateRes
       const cachedData = await AsyncStorage.getItem(JWCH_LOCATE_DATE_CACHE_KEY);
 
       if (cachedData) {
-        const { date: cachedDate, week, year, term } = JSON.parse(cachedData);
+        const {
+          date: cachedDate,
+          week,
+          year,
+          term,
+        }: { date: string; week: number; year: number; term: number } = JSON.parse(cachedData);
         const semester = `${year}${term.toString().padStart(2, '0')}`;
         // 如果缓存日期是同一周的，直接返回缓存数据；否则先返回计算值，再异步更新
         if (currentDate.isSame(cachedDate, 'isoWeek')) {
           console.log('Using cached locate date:', { date: formattedCurrentDate, week, day: currentDay, semester });
           return { date: formattedCurrentDate, week, day: currentDay, semester };
         } else {
-          const computedWeek = week + currentDate.diff(dayjs(cachedDate), 'week'); // 跨周了，需要计算当前是第几周
+          const cachedDateObj = dayjs(cachedDate);
+          const shift = currentDate.isoWeek() - cachedDateObj.isoWeek(); // 计算周数差
+          const computedWeek = week + shift; // 跨周了，需要计算当前是第几周
           console.log('Cached locate date is outdated, computed data:', {
             date: formattedCurrentDate,
             week: computedWeek,
@@ -96,23 +103,12 @@ export default async function locateDate(noCache = false): Promise<LocateDateRes
 
 // 根据学期开始日期和当前周数获取当前周的第一天日期
 export function getFirstDateByWeek(semesterStart: string, currentWeek: number): string {
-  const startDate = dayjs(semesterStart);
-  const startDayOfWeek = (startDate.day() + 6) % 7; // 将星期日（0）转换为 6，其他天数减 1 对应星期一到星期六
-  const adjustedStartDate = startDate.subtract(startDayOfWeek, 'day');
+  const adjustedStartDate = dayjs(semesterStart).startOf('isoWeek');
 
   // 如果学期开始日期不是星期一，则调整到最近的星期一
   const firstDayOfWeek = adjustedStartDate.add((currentWeek - 1) * 7, 'day');
 
   return firstDayOfWeek.format(DATE_FORMAT_DASH); // 返回日期字符串格式 YYYY-MM-DD
-}
-
-// 根据学期开始日期和当前周数获取当前周的日期（会返回一个完整的一周）
-export function getDatesByWeek(semesterStart: string, currentWeek: number): string[] {
-  const firstDayOfWeek = dayjs(getFirstDateByWeek(semesterStart, currentWeek));
-
-  return Array.from({ length: 7 }, (_, i) => {
-    return firstDayOfWeek.add(i, 'day').format(DATE_FORMAT_DASH); // 返回日期字符串格式 YYYY-MM-DD
-  });
 }
 
 // 根据学期开始日期和结束日期计算一学期一共有多少周


### PR DESCRIPTION
## 改动说明

优化课程详情弹窗的周数显示逻辑。

## 改动前

只显示当前选中的时间段（如 `6-9周`），其他时间段（如 `1-5周`）不显示。

## 改动后

显示课程的所有时间段，用顿号分隔（如 `1-5周、6-9周`）。

## 优化点

- 单周不再显示为 `5-5周`，改为 `5周`
- 保留单双周标记（`[单]`、`[双]`）