### PR TITLE
fix: 统一考场缓存数据形状

### DIFF
--- a/app/toolbox/exam-room.tsx
+++ b/app/toolbox/exam-room.tsx
@@ -28,7 +28,7 @@ interface TermContentProps {
 
 const TermContent = React.memo<TermContentProps>(({ term }) => {
   const { width: screenWidth } = useWindowDimensions(); // 获取屏幕宽度
-  const apiResult = useApiRequest(getApiV1JwchClassroomExam, { term }, { queryKey: [EXAM_ROOM_KEY, 'toolbox', term] });
+  const apiResult = useApiRequest(getApiV1JwchClassroomExam, { term }, { queryKey: [EXAM_ROOM_KEY, term] });
   const { data, dataUpdatedAt, isFetching, refetch } = apiResult;
 
   const { state } = useMultiStateRequest(apiResult, {

--- a/app/toolbox/exam-room.tsx
+++ b/app/toolbox/exam-room.tsx
@@ -28,7 +28,7 @@ interface TermContentProps {
 
 const TermContent = React.memo<TermContentProps>(({ term }) => {
   const { width: screenWidth } = useWindowDimensions(); // 获取屏幕宽度
-  const apiResult = useApiRequest(getApiV1JwchClassroomExam, { term }, { queryKey: [EXAM_ROOM_KEY, term] });
+  const apiResult = useApiRequest(getApiV1JwchClassroomExam, { term }, { queryKey: [EXAM_ROOM_KEY, 'toolbox', term] });
   const { data, dataUpdatedAt, isFetching, refetch } = apiResult;
 
   const { state } = useMultiStateRequest(apiResult, {

--- a/hooks/useCourseDataSuspense.ts
+++ b/hooks/useCourseDataSuspense.ts
@@ -61,11 +61,11 @@ async function loadCourseAndExamData(
     try {
       const examData = await fetchWithCache(
         [EXAM_ROOM_KEY, queryTerm],
-        () => getApiV1JwchClassroomExam({ term: queryTerm }),
+        () => getApiV1JwchClassroomExam({ term: queryTerm }).then(r => r.data.data),
         { staleTime: EXPIRE_ONE_DAY },
       );
 
-      const formattedExamData = formatExamData(examData.data.data);
+      const formattedExamData = formatExamData(examData);
       if (!CourseCache.compareDigest(EXAM_TYPE, formattedExamData)) {
         CourseCache.mergeExamCourses(formattedExamData, currentTerm.start_date, currentTerm.end_date);
         hasChanged = true;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -105,7 +105,7 @@ export const TOOLBOX_CONFIG_KEY = 'toolbox_config';
 export const TOOLBOX_BANNER_KEY = 'toolbox_banner';
 
 // 考场
-export const EXAM_ROOM_KEY = 'exam_room';
+export const EXAM_ROOM_KEY = 'exam_room_v2';
 
 // 成绩
 export const GRADE_LIST_KEY = 'grade_list';

--- a/lib/course.ts
+++ b/lib/course.ts
@@ -918,13 +918,13 @@ export const forceRefreshCourseData = async (queryTerm: string) => {
   if ((await getCourseSetting()).exportExamToCourseTable) {
     const examData = await fetchWithCache(
       [EXAM_ROOM_KEY, queryTerm],
-      () => getApiV1JwchClassroomExam({ term: queryTerm }),
+      () => getApiV1JwchClassroomExam({ term: queryTerm }).then(r => r.data.data),
       {
         staleTime: 0,
       },
     );
 
-    const formattedExamData = formatExamData(examData.data.data);
+    const formattedExamData = formatExamData(examData);
     const termsList = await fetchWithCache([COURSE_TERMS_LIST_KEY], () => getApiV1TermsList(), {
       staleTime: 0,
     });


### PR DESCRIPTION
课表页将完整响应对象写入考场缓存，工具箱考场查询缓存的是解包后的数据，形状不一致导致工具箱考场查询崩溃。

改动后统一解包 `.data.data` 再缓存。~旧脏数据 1 天过期，合入后需 1 天才能恢复~。