### PR TITLE
fix(harmony): 显式指定目标设备类型

### DIFF
--- a/application-support/harmony-template/entry/src/main/module.json5
+++ b/application-support/harmony-template/entry/src/main/module.json5
@@ -6,7 +6,7 @@
     "mainElement": "EntryAbility",
     "srcEntry": "./ets/abilityStage/EntryAbilityStage.ets",
     "deviceTypes": [
-      "default"
+      "phone"
     ],
     "deliveryWithInstall": true,
     "installationFree": false,

--- a/application-support/harmony-template/expo_quick_actions/src/main/module.json5
+++ b/application-support/harmony-template/expo_quick_actions/src/main/module.json5
@@ -3,7 +3,7 @@
     "name": "expo_quick_actions",
     "type": "har",
     "deviceTypes": [
-      "default"
+      "phone"
     ]
   }
 }


### PR DESCRIPTION
上架审核要求

https://developer.huawei.com/consumer/cn/forum/topic/0203205751235535562?fid=0102104600515103427

```log
测试步骤：1. entry-default.hap申明所支持的设备类型超出[tablet, tv, wearable, 2in1, phone, car]这六种类型范围;
2. entry-default.hap申明所支持的设备类型超出[tablet, tv, wearable, 2in1, phone, car]这六种类型范围;
3. entry-default.hap申明所支持的设备类型超出[tablet, tv, wearable, 2in1, phone, car]这六种类型范围;
测试环境：WIFI联网、HarmonyOS 6.1(Mate 60)、API6.1.0(23)、中文环境，WIFI联网、HarmonyOS 6.1(Mate 60)、API6.1.1(24)、中文环境，WIFI联网、HarmonyOS 6.1(Mate X5)、API6.1.1(24)、中文环境
```